### PR TITLE
chore(build): analyze and reduce target artifact growth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,17 @@ rustls = { version = "0.23", features = ["ring"] }
 
 [dev-dependencies]
 tokio-test = "0.4"
+
+[profile.dev]
+# Keep debug info for this crate, but avoid full symbols for all dependencies.
+# This significantly reduces target/debug size during iterative development.
+debug = 1
+
+[profile.dev.package."*"]
+debug = 0
+
+[profile.test]
+debug = 1
+
+[profile.test.package."*"]
+debug = 0

--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ Full raw output is saved at `docs/assets/cargo-run-output.txt`.
 tail -f sandbox-quant.log | jq .
 ```
 
+## Build Artifact Size
+
+If `target/` grows too large during local iteration, see:
+
+- `docs/target-size-analysis.md`
+
 ## Project Layout
 
 ```text

--- a/docs/target-size-analysis.md
+++ b/docs/target-size-analysis.md
@@ -1,0 +1,45 @@
+# Target Size Analysis
+
+Date: 2026-02-13
+
+## Summary
+
+`target/` size was measured at about `2.8G`. The largest contributors were:
+
+- `target/debug/deps`: about `2.0G`
+- `target/debug/incremental`: about `441M`
+- `target/doc`: about `276M`
+
+This pattern indicates repeated local debug/test builds plus generated Rust docs.
+
+## Root Cause
+
+- Rust dependency artifacts include large debug symbols by default.
+- Incremental compilation caches accumulate across build graph changes.
+- `cargo doc` output for the full dependency graph is large.
+
+## Mitigation Added In This PR
+
+- `Cargo.toml` now keeps debug info for this crate but disables heavy debug symbols for dependencies in `dev` and `test` profiles.
+- This reduces long-term growth of `target/debug` while preserving useful local debugging for project code.
+
+## Operational Commands
+
+Check current size:
+
+```bash
+du -sh target
+du -h -d 2 target | sort -hr | head -n 20
+```
+
+One-time cleanup:
+
+```bash
+cargo clean
+```
+
+Doc-only cleanup:
+
+```bash
+rm -rf target/doc
+```


### PR DESCRIPTION
## Summary
- analyzed local target usage (observed about 2.8G total) and documented major contributors
- added dev/test profile tuning to reduce dependency debug symbol bloat in target/debug
- documented cleanup and inspection commands for recurring maintenance

## Root Cause Analysis
Observed breakdown:
- target/debug/deps: about 2.0G
- target/debug/incremental: about 441M
- target/doc: about 276M

Likely drivers:
- dependency debug symbols in iterative debug/test builds
- accumulated incremental caches across frequent code changes
- generated cargo docs for dependency graph

## Changes
- Cargo.toml
  - set profile.dev and profile.test to keep local debug info (debug = 1)
  - set profile.dev.package.* and profile.test.package.* to debug = 0 for dependencies
- docs/target-size-analysis.md
  - documented measurements, cause hypotheses, and cleanup commands
- README.md
  - linked the new target-size analysis guide

## Validation
- cargo check -q failed here due crates.io DNS/network restriction
- cargo check -q --offline failed due missing local index/cache for some crates

No runtime code path was changed in this PR.