### PR TITLE
Daemonize recorder and trading engine services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,0 @@
-BINANCE_API_KEY=your_binance_api_key_here
-BINANCE_SECRET_KEY=your_binance_secret_key_here
-
-# Optional overrides
-# BINANCE_SPOT_BASE_URL=https://api.binance.com
-# BINANCE_FUTURES_BASE_URL=https://fapi.binance.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 /target
+/.omx
+/codex-skills
+/watchdog-context
 .env
 .env.example
 *.log
@@ -6,3 +9,4 @@
 data/*.sqlite
 data/*.json
 docs-site/book/
+watchdog-context/*.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,6 +649,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2147,6 +2199,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2159,6 +2217,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -2731,6 +2790,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2778,6 +2843,12 @@ dependencies = [
  "objc",
  "paste",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -4134,6 +4205,7 @@ name = "sandbox-quant"
 version = "1.0.10"
 dependencies = [
  "anyhow",
+ "axum",
  "chrono",
  "crossterm",
  "dotenvy",
@@ -4242,6 +4314,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4970,6 +5053,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,13 +2,13 @@
 name = "sandbox-quant"
 version = "1.0.10"
 edition = "2021"
-description = "Exchange-truth trading core for Binance Spot and Futures"
+description = "Integrated trading project for collector, recorder, backtest, GUI, and execution services"
 repository = "https://github.com/sehyunsix/sandbox-quant"
 readme = "README.md"
-documentation = "https://docs.rs/sandbox-quant"
 keywords = ["trading", "binance", "exchange", "cli", "futures"]
 categories = ["command-line-utilities", "finance"]
 license = "MIT"
+publish = false
 exclude = [
     "archive/**",
     "docs/archive/**",
@@ -22,6 +22,7 @@ gui = ["dep:eframe", "dep:plotters"]
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
+axum = { version = "0.8", features = ["json"] }
 reqwest = { version = "0.12", features = ["blocking", "json", "rustls-tls"], default-features = false }
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
 futures-util = "0.3"

--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ Storage-specific env vars:
 
 - `SANDBOX_QUANT_RECORDER_STORAGE=duckdb|postgres` selects the live recorder sink
 - `SANDBOX_QUANT_POSTGRES_URL` (or `DATABASE_URL`) is used by PostgreSQL-backed recorder/collector flows
+- `SANDBOX_QUANT_BACKTEST_SOURCE=postgres` makes `sandbox-quant-backtest run` read source market data directly from PostgreSQL
 - `SANDBOX_QUANT_BACKTEST_AUTO_SNAPSHOT=postgres` makes backtest `run` pull the requested symbol/date range from PostgreSQL into DuckDB before executing
+- `SANDBOX_QUANT_BACKTEST_EXPORT_POSTGRES=1` forces backtest runs to export summary, trades, and equity points into PostgreSQL for Grafana
 - `SANDBOX_QUANT_BACKTEST_SNAPSHOT_PRODUCT` / `SANDBOX_QUANT_BACKTEST_SNAPSHOT_INTERVAL` can narrow the imported snapshot
 
 ## Binaries
@@ -158,6 +160,9 @@ Storage-specific env vars:
 - `sandbox-quant-collector`
   - one-shot historical Binance public data backfill
   - `binance-public import`, `summary`, `snapshot postgres-to-duckdb`
+- `sandbox-quant-watchdog`
+  - PostgreSQL freshness probe for recorder market data
+  - non-interactive operational helper for recorder freshness checks
 - `sandbox-quant-gui`
   - optional desktop GUI for charting + backtest exploration
   - requires Cargo feature `gui`
@@ -170,6 +175,33 @@ Operator shell:
 
 ```bash
 cargo run --bin sandbox-quant
+```
+
+Trading-engine daemon mode:
+
+```bash
+cargo run --bin sandbox-quant -- serve --mode demo --base-dir var --listen 127.0.0.1:9782
+```
+
+Trading-engine daemon control:
+
+```bash
+cargo run --bin sandbox-quant -- status --listen 127.0.0.1:9782
+cargo run --bin sandbox-quant -- health --listen 127.0.0.1:9782
+cargo run --bin sandbox-quant -- stop --listen 127.0.0.1:9782
+```
+
+Trading-engine daemon command API examples:
+
+```bash
+curl -s -X POST http://127.0.0.1:9782/refresh
+curl -s -X POST http://127.0.0.1:9782/close-all
+curl -s -X POST http://127.0.0.1:9782/close-symbol \
+  -H 'content-type: application/json' \
+  -d '{"instrument":"BTCUSDT"}'
+curl -s -X POST http://127.0.0.1:9782/set-target-exposure \
+  -H 'content-type: application/json' \
+  -d '{"instrument":"BTCUSDT","target":0.25,"order_type":"market"}'
 ```
 
 Refresh authoritative state:
@@ -209,7 +241,7 @@ Options orders are handled as a separate workflow. They appear in portfolio posi
 Recorder terminal:
 
 ```bash
-cargo run --bin sandbox-quant-recorder -- --mode demo
+cargo run --bin sandbox-quant-recorder
 ```
 
 Recorder terminal with PostgreSQL sink:
@@ -217,7 +249,47 @@ Recorder terminal with PostgreSQL sink:
 ```bash
 export SANDBOX_QUANT_RECORDER_STORAGE=postgres
 export SANDBOX_QUANT_POSTGRES_URL=postgres://localhost/sandbox_quant
-cargo run --bin sandbox-quant-recorder -- --mode demo
+cargo run --bin sandbox-quant-recorder
+```
+
+YAML-based runtime launcher:
+
+```bash
+bash ops/run-runtime.sh ops/grafana/.env recorder
+bash ops/run-runtime.sh ops/grafana/.env trading_engine
+bash ops/run-runtime.sh ops/grafana/.env backfill_binance
+bash ops/run-runtime.sh ops/grafana/.env backfill_fx
+bash ops/run-runtime.sh ops/grafana/.env backfill_kr
+```
+
+The launcher reads service defaults from [ops/runtime.yaml](/Users/yuksehyun/project/sandbox-quant/ops/runtime.yaml) and derives `SANDBOX_QUANT_POSTGRES_URL` from the env file, so operators do not need to type long `export` sequences manually.
+
+Recorder with integrated Binance 1m backfill sidecar:
+
+```bash
+cargo run --bin sandbox-quant-recorder -- \
+  serve BTCUSDT ETHUSDT SOLUSDT XRPUSDT \
+  --backfill \
+  --backfill-poll-seconds 30
+```
+
+This starts the recorder daemon and also spawns `postgres_kline_backfill` as a child process so current-day `raw_klines` stay fresh alongside websocket event ingest.
+
+Long-running recorder processes now emit heartbeat JSON logs every 5 seconds with `kind=heartbeat`, including `ping_at`, `pong_at`, `heartbeat_age_sec`, `reader_alive`, `writer_alive`, `worker_alive`, and watched symbols. Those logs are written to `var/log/recorder.jsonl` by default and are intended for Loki/Grafana operational monitoring.
+
+Recorder daemon control:
+
+```bash
+cargo run --bin sandbox-quant-recorder -- status --listen 127.0.0.1:9781
+cargo run --bin sandbox-quant-recorder -- health --listen 127.0.0.1:9781
+cargo run --bin sandbox-quant-recorder -- freshness --listen 127.0.0.1:9781
+cargo run --bin sandbox-quant-recorder -- stop --listen 127.0.0.1:9781
+```
+
+Recorder watchdog probe against PostgreSQL + recorder heartbeat:
+
+```bash
+cargo run --bin sandbox-quant-watchdog -- probe
 ```
 
 Then inside the recorder terminal:
@@ -237,21 +309,54 @@ cargo run --bin sandbox-quant-backtest -- --mode demo
 One-shot dataset run:
 
 ```bash
-target/debug/sandbox-quant-backtest run liquidation-breakdown-short BTCUSDT --from 2026-03-13 --to 2026-03-13 --mode demo --base-dir var
+cargo run --bin sandbox-quant-backtest -- \
+  run liquidation-breakdown-short BTCUSDT --from 2026-03-13 --to 2026-03-13 --mode demo --base-dir var
 ```
+
+Direct PostgreSQL-backed backtest run without DuckDB source reads:
+
+```bash
+export SANDBOX_QUANT_BACKTEST_SOURCE=postgres
+export SANDBOX_QUANT_BACKTEST_EXPORT_POSTGRES=1
+export SANDBOX_QUANT_POSTGRES_URL=postgres://localhost/sandbox_quant
+cargo run --bin sandbox-quant-backtest -- \
+  run price-sma-cross-long BTCUSDT --from 2026-01-01 --to 2026-03-15 --mode demo
+```
+
+In direct mode, the CLI reads `raw_klines` from PostgreSQL and writes the result set back to PostgreSQL for Grafana. DuckDB is bypassed for the source dataset.
+
+PostgreSQL sweep script for repeated strategy experiments with Grafana-visible exports:
+
+```bash
+ops/backtest-postgres-sweep.sh
+```
+
+Useful overrides:
+
+```bash
+MODE=demo \
+INSTRUMENTS_CSV=BTCUSDT,ETHUSDT,SOLUSDT \
+TEMPLATES_CSV=price-sma-cross-long,price-sma-cross-short,price-sma-cross-long-fast,price-sma-cross-short-fast \
+DATE_WINDOWS_CSV=2026-03-01:2026-03-15,2026-03-16:2026-03-18 \
+ops/backtest-postgres-sweep.sh
+```
+
+The sweep script uses the existing PostgreSQL export path, so each run is inserted into `backtest_runs`, `backtest_trades`, and `backtest_equity_points` for the Grafana `sandbox-quant backtest pnl` dashboard.
+
+When the trading engine runs in shell or explicit `run` mode, it emits heartbeat JSON logs every 5 seconds with `kind=heartbeat`, `heartbeat_age_sec=0`, DuckDB path visibility, and latest local market-data freshness so the process can be monitored from Grafana/Loki.
 
 If `--from` is after `--to`, the command now fails fast with an invalid date-range error before touching the dataset DB.
 
 List recent runs:
 
 ```bash
-target/debug/sandbox-quant-backtest list --mode demo --base-dir var
+cargo run --bin sandbox-quant-backtest -- list --mode demo --base-dir var
 ```
 
 Show the latest persisted report:
 
 ```bash
-target/debug/sandbox-quant-backtest report latest --mode demo --base-dir var
+cargo run --bin sandbox-quant-backtest -- report latest --mode demo --base-dir var
 ```
 
 Export the latest persisted backtest run into PostgreSQL for Grafana:
@@ -310,6 +415,17 @@ PostgreSQL summary:
 ```bash
 cargo run --bin sandbox-quant-collector -- summary --storage postgres
 ```
+
+Unified PostgreSQL backfill wrapper:
+
+```bash
+bash ops/backfill-postgres.sh ops/grafana/.env binance
+bash ops/backfill-postgres.sh ops/grafana/.env fx
+bash ops/backfill-postgres.sh ops/grafana/.env kr
+bash ops/backfill-postgres.sh ops/grafana/.env all
+```
+
+Use this wrapper as the operator-facing entrypoint for source-specific PostgreSQL kline backfills.
 
 Backtest-ready DuckDB snapshot exported from PostgreSQL:
 

--- a/ops/backfill-postgres.sh
+++ b/ops/backfill-postgres.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+unset LC_ALL
+
+usage() {
+  cat >&2 <<'EOF'
+usage: backfill-postgres.sh <env-file> <source> [options]
+
+sources:
+  binance   run postgres_kline_backfill
+  fx        run postgres_fx_kline_backfill
+  kr        run postgres_kr_exchange_kline_backfill
+  all       run all three in sequence
+
+examples:
+  bash ops/backfill-postgres.sh ops/grafana/.env binance
+  bash ops/backfill-postgres.sh ops/grafana/.env fx
+  bash ops/backfill-postgres.sh ops/grafana/.env kr
+  bash ops/backfill-postgres.sh ops/grafana/.env all
+EOF
+}
+
+if [ "$#" -lt 2 ]; then
+  usage
+  exit 64
+fi
+
+env_file=$1
+source_name=$2
+shift 2
+
+if [ ! -f "$env_file" ]; then
+  echo "env file not found: $env_file" >&2
+  exit 66
+fi
+
+set -a
+# shellcheck disable=SC1090
+. "$env_file"
+set +a
+
+export SANDBOX_QUANT_POSTGRES_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:${POSTGRES_PORT:-5432}/${POSTGRES_DB}"
+
+run_bin() {
+  local bin_name=$1
+  shift
+  cargo run --bin "$bin_name" -- "$@"
+}
+
+case "$source_name" in
+  binance)
+    run_bin postgres_kline_backfill "$@"
+    ;;
+  fx)
+    run_bin postgres_fx_kline_backfill "$@"
+    ;;
+  kr)
+    run_bin postgres_kr_exchange_kline_backfill "$@"
+    ;;
+  all)
+    run_bin postgres_kline_backfill "$@"
+    run_bin postgres_fx_kline_backfill "$@"
+    run_bin postgres_kr_exchange_kline_backfill "$@"
+    ;;
+  *)
+    echo "unsupported source: $source_name" >&2
+    usage
+    exit 64
+    ;;
+esac

--- a/ops/backtest-postgres-sweep.sh
+++ b/ops/backtest-postgres-sweep.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GRAFANA_ENV_FILE="${GRAFANA_ENV_FILE:-$ROOT_DIR/ops/grafana/.env.example}"
+BACKTEST_BIN="${BACKTEST_BIN:-$ROOT_DIR/target/debug/sandbox-quant-backtest}"
+MODE="${MODE:-demo}"
+BASE_DIR="${BASE_DIR:-var}"
+INSTRUMENTS_CSV="${INSTRUMENTS_CSV:-BTCUSDT,ETHUSDT}"
+TEMPLATES_CSV="${TEMPLATES_CSV:-price-sma-cross-long,price-sma-cross-short,price-sma-cross-long-fast,price-sma-cross-short-fast}"
+DATE_WINDOWS_CSV="${DATE_WINDOWS_CSV:-2026-03-01:2026-03-15,2026-03-16:2026-03-18}"
+OUTPUT_DIR="${OUTPUT_DIR:-$ROOT_DIR/var/backtest-sweeps}"
+
+load_env_file() {
+  local file="$1"
+  local line name value
+  [[ -f "$file" ]] || return 0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -n "$line" ]] || continue
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+    [[ "$line" == *=* ]] || continue
+    name="${line%%=*}"
+    value="${line#*=}"
+    name="${name#"${name%%[![:space:]]*}"}"
+    name="${name%"${name##*[![:space:]]}"}"
+    if [[ "$name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      export "$name=$value"
+    fi
+  done < "$file"
+}
+
+ensure_postgres_url() {
+  if [[ -n "${SANDBOX_QUANT_POSTGRES_URL:-}" ]]; then
+    return 0
+  fi
+  load_env_file "$GRAFANA_ENV_FILE"
+  if [[ -z "${POSTGRES_USER:-}" || -z "${POSTGRES_PASSWORD:-}" || -z "${POSTGRES_DB:-}" ]]; then
+    echo "missing PostgreSQL credentials; set SANDBOX_QUANT_POSTGRES_URL or prepare ops/grafana/.env.example" >&2
+    exit 2
+  fi
+  export SANDBOX_QUANT_POSTGRES_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT:-5432}/${POSTGRES_DB}"
+}
+
+ensure_backtest_bin() {
+  if [[ -x "$BACKTEST_BIN" ]]; then
+    return 0
+  fi
+  (cd "$ROOT_DIR" && cargo build -q --bin sandbox-quant-backtest)
+}
+
+ensure_postgres_url
+ensure_backtest_bin
+
+export SANDBOX_QUANT_BACKTEST_SOURCE="${SANDBOX_QUANT_BACKTEST_SOURCE:-postgres}"
+export SANDBOX_QUANT_BACKTEST_EXPORT_POSTGRES=1
+
+exec "$BACKTEST_BIN" sweep \
+  --templates "$TEMPLATES_CSV" \
+  --instruments "$INSTRUMENTS_CSV" \
+  --windows "$DATE_WINDOWS_CSV" \
+  --output-dir "$OUTPUT_DIR" \
+  --mode "$MODE" \
+  --base-dir "$BASE_DIR"

--- a/ops/grafana/README.md
+++ b/ops/grafana/README.md
@@ -108,6 +108,8 @@ cargo run --bin sandbox-quant-collector -- \
   --storage postgres
 ```
 
+For live websocket event ingest into PostgreSQL, use `sandbox-quant-recorder`. It is the single supported live event ingestion path for liquidation, book ticker, and agg trade data.
+
 ## Provisioned dashboard
 
 The starter dashboard includes:
@@ -121,13 +123,11 @@ The starter dashboard includes:
 
 Dashboard variables:
 
-- `mode`
 - `symbol` with multi-select support
 - `interval` as `1m`, `15m`, `30m`, `1h`
 
 Current sample expectation:
 
-- mode: `demo`
 - symbol: `BTCUSDT` or multiple symbols together
 - interval: `1h`
 - default dashboard time range: `now-1y`
@@ -145,14 +145,14 @@ The `sandbox-quant backtest pnl` dashboard reads exported backtest runs from Pos
 - `backtest_trades`
 - `backtest_equity_points`
 
-Export a persisted DuckDB backtest run into PostgreSQL with:
+Run direct PostgreSQL-backed backtests and export results for Grafana with:
 
 ```bash
 export SANDBOX_QUANT_POSTGRES_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}"
+export SANDBOX_QUANT_BACKTEST_SOURCE=postgres
+export SANDBOX_QUANT_BACKTEST_EXPORT_POSTGRES=1
 cargo run --bin sandbox-quant-backtest -- \
-  export postgres latest \
-  --mode demo \
-  --base-dir var
+  run price-sma-cross-long BTCUSDT --from 2026-01-01 --to 2026-03-15 --mode demo
 ```
 
 After export, the dashboard lets you filter by:
@@ -169,13 +169,22 @@ The `sandbox-quant system` dashboard combines:
 - PostgreSQL operational tables such as `raw_klines`, `snapshot_exports`, and `backtest_runs`
 - Loki log panels backed by Promtail scraping local runtime log files
 
+## Trading Events dashboard
+
+The `sandbox-quant trading events` dashboard focuses on:
+
+- recorder heartbeat logs
+- trading-engine heartbeat logs
+- `app.execution.started` / `app.execution.completed` decision + execution events
+- strategy watch lifecycle events
+
 Promtail currently scrapes:
 
-- `var/*.log`
-- `var/**/*.log`
+- `var/log/*.jsonl`
+- `var/log/**/*.jsonl`
 - `var/*.jsonl`
 
-The in-process operator `EventLog` now appends JSON lines to `var/operator-events.jsonl` by default, so trading-engine events can also be queried through Loki.
+The in-process operator `EventLog` appends JSON lines to `var/operator-events.jsonl` by default, and the recorder/trading-engine heartbeat logs are written under `var/log/*.jsonl`, so both can be queried through Loki.
 
 ## Copy/paste queries for Grafana panel editor
 
@@ -241,8 +250,7 @@ WITH bucketed AS (
     close,
     close_time
   FROM raw_klines
-  WHERE mode = ${mode:sqlstring}
-    AND symbol IN (${symbol:sqlstring})
+  WHERE symbol IN (${symbol:sqlstring})
     AND interval_name = '1m'
     AND $__timeFilter(open_time)
 ), ranked AS (

--- a/ops/grafana/dashboards/sandbox-quant-overview.json
+++ b/ops/grafana/dashboards/sandbox-quant-overview.json
@@ -70,7 +70,7 @@
           },
           "editorMode": "code",
           "format": "time_series",
-          "rawSql": "WITH bucketed AS (\n  SELECT\n    date_bin(\n      CASE ${interval:sqlstring}\n        WHEN '1m' THEN INTERVAL '1 minute'\n        WHEN '15m' THEN INTERVAL '15 minutes'\n        WHEN '30m' THEN INTERVAL '30 minutes'\n        WHEN '1h' THEN INTERVAL '1 hour'\n        ELSE INTERVAL '1 minute'\n      END,\n      open_time,\n      TIMESTAMPTZ '1970-01-01 00:00:00+00'\n    ) AS time,\n    symbol,\n    close,\n    close_time\n  FROM raw_klines\n  WHERE mode = ${mode:sqlstring}\n    AND symbol IN (${symbol:sqlstring})\n    AND interval_name = '1m'\n    AND $__timeFilter(open_time)\n), ranked AS (\n  SELECT\n    time,\n    symbol,\n    close AS close_price,\n    row_number() OVER (PARTITION BY symbol, time ORDER BY close_time DESC) AS row_num\n  FROM bucketed\n), sampled AS (\n  SELECT\n    time,\n    symbol,\n    close_price\n  FROM ranked\n  WHERE row_num = 1\n), normalized AS (\n  SELECT\n    time,\n    symbol,\n    ((close_price / nullif(first_value(close_price) OVER (PARTITION BY symbol ORDER BY time), 0)) - 1) * 100 AS relative_return_pct\n  FROM sampled\n)\nSELECT\n  time,\n  symbol,\n  relative_return_pct\nFROM normalized\nORDER BY 1, 2",
+          "rawSql": "WITH bucketed AS (\n  SELECT\n    date_bin(\n      CASE ${interval:sqlstring}\n        WHEN '1m' THEN INTERVAL '1 minute'\n        WHEN '15m' THEN INTERVAL '15 minutes'\n        WHEN '30m' THEN INTERVAL '30 minutes'\n        WHEN '1h' THEN INTERVAL '1 hour'\n        ELSE INTERVAL '1 minute'\n      END,\n      open_time,\n      TIMESTAMPTZ '1970-01-01 00:00:00+00'\n    ) AS time,\n    symbol,\n    close,\n    close_time\n  FROM raw_klines\n  WHERE symbol IN (${symbol:sqlstring})\n    AND interval_name = '1m'\n    AND $__timeFilter(open_time)\n), ranked AS (\n  SELECT\n    time,\n    symbol,\n    close AS close_price,\n    row_number() OVER (PARTITION BY symbol, time ORDER BY close_time DESC) AS row_num\n  FROM bucketed\n), sampled AS (\n  SELECT\n    time,\n    symbol,\n    close_price\n  FROM ranked\n  WHERE row_num = 1\n), normalized AS (\n  SELECT\n    time,\n    symbol,\n    ((close_price / nullif(first_value(close_price) OVER (PARTITION BY symbol ORDER BY time), 0)) - 1) * 100 AS relative_return_pct\n  FROM sampled\n)\nSELECT\n  time,\n  symbol,\n  relative_return_pct\nFROM normalized\nORDER BY 1, 2",
           "refId": "A",
           "sql": {
             "columns": [],
@@ -125,7 +125,7 @@
           },
           "editorMode": "code",
           "format": "time_series",
-          "rawSql": "SELECT\n  date_bin(\n    CASE ${interval:sqlstring}\n      WHEN '1m' THEN INTERVAL '1 minute'\n      WHEN '15m' THEN INTERVAL '15 minutes'\n      WHEN '30m' THEN INTERVAL '30 minutes'\n      WHEN '1h' THEN INTERVAL '1 hour'\n      ELSE INTERVAL '1 minute'\n    END,\n    open_time,\n    TIMESTAMPTZ '1970-01-01 00:00:00+00'\n  ) AS time,\n  symbol,\n  sum(volume) AS volume\nFROM raw_klines\nWHERE mode = ${mode:sqlstring}\n  AND symbol IN (${symbol:sqlstring})\n  AND interval_name = '1m'\n  AND $__timeFilter(open_time)\nGROUP BY 1, 2\nORDER BY 1, 2",
+          "rawSql": "SELECT\n  date_bin(\n    CASE ${interval:sqlstring}\n      WHEN '1m' THEN INTERVAL '1 minute'\n      WHEN '15m' THEN INTERVAL '15 minutes'\n      WHEN '30m' THEN INTERVAL '30 minutes'\n      WHEN '1h' THEN INTERVAL '1 hour'\n      ELSE INTERVAL '1 minute'\n    END,\n    open_time,\n    TIMESTAMPTZ '1970-01-01 00:00:00+00'\n  ) AS time,\n  symbol,\n  sum(volume) AS volume\nFROM raw_klines\nWHERE symbol IN (${symbol:sqlstring})\n  AND interval_name = '1m'\n  AND $__timeFilter(open_time)\nGROUP BY 1, 2\nORDER BY 1, 2",
           "refId": "A",
           "sql": {
             "columns": [],
@@ -180,7 +180,7 @@
           },
           "editorMode": "code",
           "format": "time_series",
-          "rawSql": "SELECT\n  date_bin(\n    CASE ${interval:sqlstring}\n      WHEN '1m' THEN INTERVAL '1 minute'\n      WHEN '15m' THEN INTERVAL '15 minutes'\n      WHEN '30m' THEN INTERVAL '30 minutes'\n      WHEN '1h' THEN INTERVAL '1 hour'\n      ELSE INTERVAL '1 minute'\n    END,\n    event_time,\n    TIMESTAMPTZ '1970-01-01 00:00:00+00'\n  ) AS time,\n  symbol,\n  count(*) AS liquidation_events\nFROM raw_liquidation_events\nWHERE mode = ${mode:sqlstring}\n  AND symbol IN (${symbol:sqlstring})\n  AND $__timeFilter(event_time)\nGROUP BY 1, 2\nORDER BY 1, 2",
+          "rawSql": "SELECT\n  date_bin(\n    CASE ${interval:sqlstring}\n      WHEN '1m' THEN INTERVAL '1 minute'\n      WHEN '15m' THEN INTERVAL '15 minutes'\n      WHEN '30m' THEN INTERVAL '30 minutes'\n      WHEN '1h' THEN INTERVAL '1 hour'\n      ELSE INTERVAL '1 minute'\n    END,\n    event_time,\n    TIMESTAMPTZ '1970-01-01 00:00:00+00'\n  ) AS time,\n  symbol,\n  count(*) AS liquidation_events\nFROM raw_liquidation_events\nWHERE symbol IN (${symbol:sqlstring})\n  AND $__timeFilter(event_time)\nGROUP BY 1, 2\nORDER BY 1, 2",
           "refId": "A",
           "sql": {
             "columns": [],
@@ -224,7 +224,7 @@
           },
           "editorMode": "code",
           "format": "table",
-          "rawSql": "SELECT\n  product,\n  symbol,\n  interval_name,\n  count(*) AS row_count,\n  min(open_time) AS first_open_time,\n  max(close_time) AS last_close_time\nFROM raw_klines\nWHERE mode = ${mode:sqlstring}\n  AND symbol IN (${symbol:sqlstring})\nGROUP BY 1, 2, 3\nORDER BY row_count DESC\nLIMIT 20",
+          "rawSql": "SELECT\n  product,\n  symbol,\n  interval_name,\n  count(*) AS row_count,\n  min(open_time) AS first_open_time,\n  max(close_time) AS last_close_time\nFROM raw_klines\nWHERE symbol IN (${symbol:sqlstring})\nGROUP BY 1, 2, 3\nORDER BY row_count DESC\nLIMIT 20",
           "refId": "A",
           "sql": {
             "columns": [],
@@ -334,32 +334,6 @@
   ],
   "templating": {
     "list": [
-      {
-        "current": {
-          "selected": false,
-          "text": "demo",
-          "value": "demo"
-        },
-        "hide": 0,
-        "includeAll": false,
-        "label": "Mode",
-        "multi": false,
-        "name": "mode",
-        "options": [
-          {
-            "selected": true,
-            "text": "demo",
-            "value": "demo"
-          },
-          {
-            "selected": false,
-            "text": "real",
-            "value": "real"
-          }
-        ],
-        "query": "demo,real",
-        "type": "custom"
-      },
       {
         "current": {
           "selected": false,

--- a/ops/grafana/dashboards/sandbox-quant-system.json
+++ b/ops/grafana/dashboards/sandbox-quant-system.json
@@ -253,7 +253,7 @@
           },
           "editorMode": "code",
           "format": "table",
-          "rawSql": "SELECT max(close_time) AS latest_market_time FROM raw_klines",
+          "rawSql": "SELECT greatest(\n  coalesce((SELECT max(close_time) FROM raw_klines), TIMESTAMPTZ '1970-01-01 00:00:00+00'),\n  coalesce((SELECT max(event_time) FROM raw_book_ticker), TIMESTAMPTZ '1970-01-01 00:00:00+00'),\n  coalesce((SELECT max(event_time) FROM raw_agg_trades), TIMESTAMPTZ '1970-01-01 00:00:00+00'),\n  coalesce((SELECT max(event_time) FROM raw_liquidation_events), TIMESTAMPTZ '1970-01-01 00:00:00+00')\n) AS latest_market_time",
           "refId": "A",
           "sql": {
             "columns": [],
@@ -262,6 +262,446 @@
         }
       ],
       "title": "Latest Market Time",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sandbox-quant-loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "false"
+                },
+                "1": {
+                  "text": "true"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 10
+      },
+      "id": 14,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "sandbox-quant-loki"
+          },
+          "editorMode": "code",
+          "expr": "(max(max_over_time({job=\"sandbox-quant-var-logs\",service=\"recorder\",kind=\"heartbeat\"} | json | unwrap heartbeat_age_sec [5m])) > bool 30) or (sum(count_over_time({job=\"sandbox-quant-var-logs\",service=\"recorder\",kind=\"heartbeat\"} |= \"\\\"worker_alive\\\":false\" [5m])) > bool 0) or absent_over_time({job=\"sandbox-quant-var-logs\",service=\"recorder\",kind=\"heartbeat\"}[5m])",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Recorder Stale",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sandbox-quant-loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "false"
+                },
+                "1": {
+                  "text": "true"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 10
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "sandbox-quant-loki"
+          },
+          "editorMode": "code",
+          "expr": "(max(max_over_time({job=\"sandbox-quant-var-logs\",service=\"trading-engine\",kind=\"heartbeat\"} | json | unwrap heartbeat_age_sec [5m])) > bool 30) or absent_over_time({job=\"sandbox-quant-var-logs\",service=\"trading-engine\",kind=\"heartbeat\"}[5m])",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Trading Stale",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "sandbox-quant-postgres"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "false"
+                },
+                "1": {
+                  "text": "true"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 10
+      },
+      "id": 16,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "sandbox-quant-postgres"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawSql": "SELECT CASE WHEN EXTRACT(EPOCH FROM (\n  now() - greatest(\n    coalesce((SELECT max(close_time) FROM raw_klines), TIMESTAMPTZ '1970-01-01 00:00:00+00'),\n    coalesce((SELECT max(event_time) FROM raw_book_ticker), TIMESTAMPTZ '1970-01-01 00:00:00+00'),\n    coalesce((SELECT max(event_time) FROM raw_agg_trades), TIMESTAMPTZ '1970-01-01 00:00:00+00'),\n    coalesce((SELECT max(event_time) FROM raw_liquidation_events), TIMESTAMPTZ '1970-01-01 00:00:00+00')\n  )\n)) > 300 THEN 1 ELSE 0 END AS market_stale",
+          "refId": "A",
+          "sql": {
+            "columns": [],
+            "groupBy": []
+          }
+        }
+      ],
+      "title": "Market Stale",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sandbox-quant-loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 30
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 0,
+        "y": 5
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "sandbox-quant-loki"
+          },
+          "editorMode": "code",
+          "expr": "max(max_over_time({job=\"sandbox-quant-var-logs\",service=\"recorder\",kind=\"heartbeat\"} | json | unwrap heartbeat_age_sec [5m]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Recorder Heartbeat Age",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sandbox-quant-loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 30
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 8,
+        "y": 5
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "sandbox-quant-loki"
+          },
+          "editorMode": "code",
+          "expr": "max(max_over_time({job=\"sandbox-quant-var-logs\",service=\"trading-engine\",kind=\"heartbeat\"} | json | unwrap heartbeat_age_sec [5m]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Trading Heartbeat Age",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "sandbox-quant-postgres"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 60
+              },
+              {
+                "color": "red",
+                "value": 300
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 16,
+        "y": 5
+      },
+      "id": 13,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "sandbox-quant-postgres"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawSql": "SELECT EXTRACT(EPOCH FROM (\n  now() - greatest(\n    coalesce((SELECT max(close_time) FROM raw_klines), TIMESTAMPTZ '1970-01-01 00:00:00+00'),\n    coalesce((SELECT max(event_time) FROM raw_book_ticker), TIMESTAMPTZ '1970-01-01 00:00:00+00'),\n    coalesce((SELECT max(event_time) FROM raw_agg_trades), TIMESTAMPTZ '1970-01-01 00:00:00+00'),\n    coalesce((SELECT max(event_time) FROM raw_liquidation_events), TIMESTAMPTZ '1970-01-01 00:00:00+00')\n  )\n)) AS market_freshness_age_sec",
+          "refId": "A",
+          "sql": {
+            "columns": [],
+            "groupBy": []
+          }
+        }
+      ],
+      "title": "Market Freshness Age",
       "type": "stat"
     },
     {
@@ -286,7 +726,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 5
+        "y": 14
       },
       "id": 5,
       "options": {
@@ -337,7 +777,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 5
+        "y": 14
       },
       "id": 6,
       "options": {
@@ -375,7 +815,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 12
+        "y": 21
       },
       "id": 7,
       "options": {
@@ -412,7 +852,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 12
+        "y": 21
       },
       "id": 8,
       "options": {
@@ -455,7 +895,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 21
+        "y": 30
       },
       "id": 9,
       "options": {
@@ -473,7 +913,7 @@
           },
           "editorMode": "code",
           "format": "table",
-          "rawSql": "SELECT product, symbol, interval_name, count(*) AS row_count, min(open_time) AS first_open_time, max(close_time) AS last_close_time FROM raw_klines GROUP BY 1, 2, 3 ORDER BY last_close_time DESC NULLS LAST LIMIT 20",
+          "rawSql": "WITH kline_rows AS (\n  SELECT 'raw_klines' AS source, product, symbol, interval_name, count(*) AS row_count, min(open_time) AS first_time, max(close_time) AS last_time\n  FROM raw_klines\n  GROUP BY 1, 2, 3, 4\n), book_rows AS (\n  SELECT 'raw_book_ticker' AS source, NULL::text AS product, symbol, 'live' AS interval_name, count(*) AS row_count, min(event_time) AS first_time, max(event_time) AS last_time\n  FROM raw_book_ticker\n  GROUP BY 1, 3, 4\n), trade_rows AS (\n  SELECT 'raw_agg_trades' AS source, NULL::text AS product, symbol, 'live' AS interval_name, count(*) AS row_count, min(event_time) AS first_time, max(event_time) AS last_time\n  FROM raw_agg_trades\n  GROUP BY 1, 3, 4\n), liquidation_rows AS (\n  SELECT 'raw_liquidation_events' AS source, NULL::text AS product, symbol, 'live' AS interval_name, count(*) AS row_count, min(event_time) AS first_time, max(event_time) AS last_time\n  FROM raw_liquidation_events\n  GROUP BY 1, 3, 4\n)\nSELECT source, coalesce(product, 'n/a') AS product, symbol, interval_name, row_count, first_time AS first_observed_time, last_time AS last_observed_time\nFROM (\n  SELECT * FROM kline_rows\n  UNION ALL\n  SELECT * FROM book_rows\n  UNION ALL\n  SELECT * FROM trade_rows\n  UNION ALL\n  SELECT * FROM liquidation_rows\n) combined\nORDER BY last_observed_time DESC NULLS LAST, source, symbol\nLIMIT 20",
           "refId": "A",
           "sql": {
             "columns": [],
@@ -499,7 +939,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 21
+        "y": 30
       },
       "id": 10,
       "options": {

--- a/ops/grafana/dashboards/sandbox-quant-trading-events.json
+++ b/ops/grafana/dashboards/sandbox-quant-trading-events.json
@@ -1,0 +1,298 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sandbox-quant-loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "sandbox-quant-loki"
+          },
+          "editorMode": "code",
+          "expr": "sum(count_over_time({job=\"sandbox-quant-var-logs\",service=\"recorder\",kind=\"heartbeat\"}[5m]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Recorder Heartbeats (5m)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sandbox-quant-loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "sandbox-quant-loki"
+          },
+          "editorMode": "code",
+          "expr": "sum(count_over_time({job=\"sandbox-quant-var-logs\",service=\"trading-engine\",kind=\"heartbeat\"}[5m]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Trading Engine Heartbeats (5m)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sandbox-quant-loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 1,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "sandbox-quant-loki"
+          },
+          "editorMode": "code",
+          "expr": "sum by (kind) (count_over_time({job=\"sandbox-quant-event-log\", kind=~\"app.execution.started|app.execution.completed|app.strategy.watch_started|app.strategy.watch_stopped\"}[$__interval]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Trading Event Volume",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sandbox-quant-loki"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 4,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "sandbox-quant-loki"
+          },
+          "editorMode": "code",
+          "expr": "{job=\"sandbox-quant-var-logs\", kind=\"heartbeat\"}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Recent Heartbeat Logs",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sandbox-quant-loki"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 5,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "sandbox-quant-loki"
+          },
+          "editorMode": "code",
+          "expr": "{job=\"sandbox-quant-event-log\", kind=~\"app.execution.started|app.execution.completed|app.strategy.watch_started|app.strategy.watch_stopped|app.market_data.price_refreshed\"}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Recent Trading Decisions And Executions",
+      "type": "logs"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "sandbox-quant",
+    "trading",
+    "events",
+    "heartbeat"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "sandbox-quant trading events",
+  "uid": "sandbox-quant-trading-events",
+  "version": 1,
+  "weekStart": ""
+}

--- a/ops/grafana/loki-config.yaml
+++ b/ops/grafana/loki-config.yaml
@@ -9,6 +9,10 @@ common:
   ring:
     kvstore:
       store: inmemory
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
 
 schema_config:
   configs:
@@ -19,11 +23,6 @@ schema_config:
       index:
         prefix: index_
         period: 24h
-
-storage_config:
-  filesystem:
-    chunks_directory: /loki/chunks
-    rules_directory: /loki/rules
 
 limits_config:
   allow_structured_metadata: false

--- a/ops/grafana/postgres-init/001-market-data-schema.sql
+++ b/ops/grafana/postgres-init/001-market-data-schema.sql
@@ -6,7 +6,6 @@ CREATE TABLE IF NOT EXISTS schema_metadata (
 
 CREATE TABLE IF NOT EXISTS raw_liquidation_events (
   event_id BIGSERIAL PRIMARY KEY,
-  mode TEXT NOT NULL,
   product TEXT NOT NULL,
   symbol TEXT NOT NULL,
   event_time TIMESTAMPTZ NOT NULL,
@@ -19,11 +18,10 @@ CREATE TABLE IF NOT EXISTS raw_liquidation_events (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS raw_liquidation_events_natural_idx
-ON raw_liquidation_events (mode, product, symbol, event_time, force_side, price, qty);
+ON raw_liquidation_events (product, symbol, event_time, force_side, price, qty);
 
 CREATE TABLE IF NOT EXISTS raw_book_ticker (
   tick_id BIGSERIAL PRIMARY KEY,
-  mode TEXT NOT NULL,
   symbol TEXT NOT NULL,
   event_time TIMESTAMPTZ NOT NULL,
   receive_time TIMESTAMPTZ NOT NULL,
@@ -34,11 +32,10 @@ CREATE TABLE IF NOT EXISTS raw_book_ticker (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS raw_book_ticker_natural_idx
-ON raw_book_ticker (mode, symbol, event_time, bid, ask, bid_qty, ask_qty);
+ON raw_book_ticker (symbol, event_time, bid, ask, bid_qty, ask_qty);
 
 CREATE TABLE IF NOT EXISTS raw_agg_trades (
   trade_id BIGSERIAL PRIMARY KEY,
-  mode TEXT NOT NULL,
   symbol TEXT NOT NULL,
   event_time TIMESTAMPTZ NOT NULL,
   receive_time TIMESTAMPTZ NOT NULL,
@@ -48,11 +45,10 @@ CREATE TABLE IF NOT EXISTS raw_agg_trades (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS raw_agg_trades_natural_idx
-ON raw_agg_trades (mode, symbol, event_time, price, qty, is_buyer_maker);
+ON raw_agg_trades (symbol, event_time, price, qty, is_buyer_maker);
 
 CREATE TABLE IF NOT EXISTS raw_klines (
   kline_id BIGSERIAL PRIMARY KEY,
-  mode TEXT NOT NULL,
   product TEXT NOT NULL,
   symbol TEXT NOT NULL,
   interval_name TEXT NOT NULL,
@@ -71,7 +67,77 @@ CREATE TABLE IF NOT EXISTS raw_klines (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS raw_klines_natural_idx
-ON raw_klines (mode, product, symbol, interval_name, open_time);
+ON raw_klines (product, symbol, interval_name, open_time);
+
+CREATE TABLE IF NOT EXISTS backtest_runs (
+  export_run_id BIGSERIAL PRIMARY KEY,
+  source_db_path TEXT NOT NULL,
+  source_run_id BIGINT NOT NULL,
+  exported_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  mode TEXT NOT NULL,
+  template TEXT NOT NULL,
+  instrument TEXT NOT NULL,
+  from_date DATE NOT NULL,
+  to_date DATE NOT NULL,
+  liquidation_events BIGINT NOT NULL,
+  book_ticker_events BIGINT NOT NULL,
+  agg_trade_events BIGINT NOT NULL,
+  derived_kline_1s_bars BIGINT NOT NULL,
+  trigger_count BIGINT NOT NULL,
+  closed_trades BIGINT NOT NULL,
+  open_trades BIGINT NOT NULL,
+  wins BIGINT NOT NULL,
+  losses BIGINT NOT NULL,
+  skipped_triggers BIGINT NOT NULL,
+  starting_equity DOUBLE PRECISION NOT NULL,
+  ending_equity DOUBLE PRECISION NOT NULL,
+  net_pnl DOUBLE PRECISION NOT NULL,
+  observed_win_rate DOUBLE PRECISION NOT NULL,
+  average_net_pnl DOUBLE PRECISION NOT NULL,
+  configured_expected_value DOUBLE PRECISION NOT NULL,
+  risk_pct DOUBLE PRECISION NOT NULL,
+  win_rate_assumption DOUBLE PRECISION NOT NULL,
+  r_multiple DOUBLE PRECISION NOT NULL,
+  max_entry_slippage_pct DOUBLE PRECISION NOT NULL,
+  stop_distance_pct DOUBLE PRECISION NOT NULL,
+  UNIQUE (source_db_path, source_run_id)
+);
+
+CREATE INDEX IF NOT EXISTS backtest_runs_mode_lookup_idx
+ON backtest_runs (mode, instrument, template, export_run_id DESC);
+
+CREATE TABLE IF NOT EXISTS backtest_trades (
+  export_run_id BIGINT NOT NULL REFERENCES backtest_runs (export_run_id) ON DELETE CASCADE,
+  trade_id BIGINT NOT NULL,
+  trigger_time TIMESTAMPTZ NOT NULL,
+  entry_time TIMESTAMPTZ NOT NULL,
+  entry_price DOUBLE PRECISION NOT NULL,
+  stop_price DOUBLE PRECISION NOT NULL,
+  take_profit_price DOUBLE PRECISION NOT NULL,
+  qty DOUBLE PRECISION NOT NULL,
+  exit_time TIMESTAMPTZ,
+  exit_price DOUBLE PRECISION,
+  exit_reason TEXT,
+  gross_pnl DOUBLE PRECISION,
+  fees DOUBLE PRECISION,
+  net_pnl DOUBLE PRECISION,
+  PRIMARY KEY (export_run_id, trade_id)
+);
+
+CREATE INDEX IF NOT EXISTS backtest_trades_exit_time_lookup_idx
+ON backtest_trades (export_run_id, exit_time);
+
+CREATE TABLE IF NOT EXISTS backtest_equity_points (
+  export_run_id BIGINT NOT NULL REFERENCES backtest_runs (export_run_id) ON DELETE CASCADE,
+  point_id BIGINT NOT NULL,
+  event_time TIMESTAMPTZ NOT NULL,
+  equity DOUBLE PRECISION NOT NULL,
+  cumulative_net_pnl DOUBLE PRECISION NOT NULL,
+  PRIMARY KEY (export_run_id, point_id)
+);
+
+CREATE INDEX IF NOT EXISTS backtest_equity_points_time_lookup_idx
+ON backtest_equity_points (export_run_id, event_time);
 
 CREATE TABLE IF NOT EXISTS backtest_runs (
   export_run_id BIGSERIAL PRIMARY KEY,

--- a/ops/grafana/promtail-config.yaml
+++ b/ops/grafana/promtail-config.yaml
@@ -10,19 +10,30 @@ clients:
 
 scrape_configs:
   - job_name: sandbox-quant-var-logs
+    pipeline_stages:
+      - json:
+          expressions:
+            service: service
+            mode: mode
+            kind: kind
+            message: message
+      - labels:
+          service:
+          mode:
+          kind:
     static_configs:
       - targets:
           - localhost
         labels:
           job: sandbox-quant-var-logs
           source: file-log
-          __path__: /workspace/var/*.log
+          __path__: /workspace/var/log/*.jsonl
       - targets:
           - localhost
         labels:
           job: sandbox-quant-var-logs
           source: file-log
-          __path__: /workspace/var/**/*.log
+          __path__: /workspace/var/log/**/*.jsonl
 
   - job_name: sandbox-quant-event-log
     pipeline_stages:

--- a/ops/run-runtime.sh
+++ b/ops/run-runtime.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+unset LC_ALL
+
+usage() {
+  cat >&2 <<'EOF'
+usage: run-runtime.sh <env-file> <service>
+
+services are defined in ops/runtime.yaml
+
+examples:
+  bash ops/run-runtime.sh ops/grafana/.env recorder
+  bash ops/run-runtime.sh ops/grafana/.env trading_engine
+  bash ops/run-runtime.sh ops/grafana/.env backfill_binance
+EOF
+}
+
+if [ "$#" -ne 2 ]; then
+  usage
+  exit 64
+fi
+
+env_file=$1
+service_name=$2
+config_path="$(dirname "$0")/runtime.yaml"
+
+if [ ! -f "$env_file" ]; then
+  echo "env file not found: $env_file" >&2
+  exit 66
+fi
+
+if [ ! -f "$config_path" ]; then
+  echo "runtime config not found: $config_path" >&2
+  exit 66
+fi
+
+set -a
+# shellcheck disable=SC1090
+. "$env_file"
+set +a
+
+export SANDBOX_QUANT_POSTGRES_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:${POSTGRES_PORT:-5432}/${POSTGRES_DB}"
+
+eval_output=$(
+  ruby -e '
+    require "yaml"
+    config = YAML.load_file(ARGV[0])
+    service = config.fetch("services").fetch(ARGV[1]) rescue nil
+    abort("unknown service: #{ARGV[1]}") if service.nil?
+    env = service["env"] || {}
+    env.each do |key, value|
+      puts "export #{key}=#{value.to_s.dump}"
+    end
+    cmd = service["command"] || []
+    abort("service command missing: #{ARGV[1]}") if cmd.empty?
+    puts "exec " + cmd.map(&:to_s).map(&:dump).join(" ")
+  ' "$config_path" "$service_name"
+)
+
+eval "$eval_output"

--- a/ops/runtime.yaml
+++ b/ops/runtime.yaml
@@ -1,0 +1,73 @@
+services:
+  recorder:
+    description: "Live market event ingest into PostgreSQL via sandbox-quant-recorder"
+    env:
+      SANDBOX_QUANT_RECORDER_STORAGE: "postgres"
+      SANDBOX_QUANT_LOG_DIR: "var/log"
+    command:
+      - cargo
+      - run
+      - --bin
+      - sandbox-quant-recorder
+      - --
+      - run
+      - BTCUSDT
+      - ETHUSDT
+      - SOLUSDT
+      - XRPUSDT
+
+  trading_engine:
+    description: "Long-running trading engine daemon mode"
+    env:
+      BINANCE_MODE: "demo"
+      SANDBOX_QUANT_LOG_DIR: "var/log"
+    command:
+      - cargo
+      - run
+      - --bin
+      - sandbox-quant
+      - --
+      - serve
+      - --mode
+      - demo
+      - --base-dir
+      - var
+
+  backfill_binance:
+    description: "Continuous Binance 1m PostgreSQL kline backfill"
+    env:
+      SANDBOX_QUANT_BACKFILL_SYMBOLS: "BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT"
+      SANDBOX_QUANT_BACKFILL_CONTINUOUS: "1"
+      SANDBOX_QUANT_BACKFILL_POLL_SECONDS: "30"
+      SANDBOX_QUANT_LOG_DIR: "var/log"
+    command:
+      - cargo
+      - run
+      - --bin
+      - postgres_kline_backfill
+
+  backfill_fx:
+    description: "Continuous Twelve Data FX 1m PostgreSQL kline backfill"
+    env:
+      SANDBOX_QUANT_FX_PAIRS: "USD/KRW,JPY/KRW,EUR/KRW,CNY/KRW"
+      SANDBOX_QUANT_FX_CONTINUOUS: "1"
+      SANDBOX_QUANT_FX_POLL_SECONDS: "60"
+      SANDBOX_QUANT_LOG_DIR: "var/log"
+    command:
+      - cargo
+      - run
+      - --bin
+      - postgres_fx_kline_backfill
+
+  backfill_kr:
+    description: "Continuous KR exchange 1m PostgreSQL kline backfill"
+    env:
+      SANDBOX_QUANT_KR_BACKFILL_ASSETS: "BTC,SOL,XRP,ETH"
+      SANDBOX_QUANT_KR_BACKFILL_CONTINUOUS: "1"
+      SANDBOX_QUANT_KR_BACKFILL_POLL_SECONDS: "60"
+      SANDBOX_QUANT_LOG_DIR: "var/log"
+    command:
+      - cargo
+      - run
+      - --bin
+      - postgres_kr_exchange_kline_backfill

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -7,6 +7,7 @@ use crate::execution::price_source::PriceSource;
 use crate::storage::event_log::log;
 use crate::strategy::command::StrategyCommand;
 use serde_json::json;
+use tracing::info;
 
 #[derive(Debug, Default)]
 pub struct AppRuntime {
@@ -49,6 +50,14 @@ impl AppRuntime {
                         "today_funding_pnl_usdt": today_funding_pnl_usdt,
                         "margin_ratio": margin_ratio,
                     }),
+                );
+                info!(
+                    service = "trading-engine",
+                    mode = app.mode.as_str(),
+                    positions = report.positions,
+                    open_order_groups = report.open_order_groups,
+                    balances = report.balances,
+                    "portfolio refreshed"
                 );
             }
             AppCommand::Execution(command) => {
@@ -111,6 +120,12 @@ impl AppRuntime {
                         );
                     }
                 }
+                info!(service = "trading-engine", mode = app.mode.as_str(), command = ?command, "execution command started");
+                log(
+                    &mut app.event_log,
+                    "app.execution.started",
+                    execution_request_payload(&command),
+                );
                 let outcome = app.execution.execute(
                     &app.exchange,
                     &app.portfolio_store,
@@ -142,6 +157,7 @@ impl AppRuntime {
                         remaining_gross_exposure_usdt(&app.portfolio_store, &app.price_store),
                     ),
                 );
+                info!(service = "trading-engine", mode = app.mode.as_str(), command = ?command, outcome = ?outcome, "execution command completed");
             }
             AppCommand::Strategy(command) => match command {
                 StrategyCommand::Templates | StrategyCommand::List | StrategyCommand::History => {}
@@ -183,6 +199,14 @@ impl AppRuntime {
                             "current_step": watch.current_step,
                         }),
                     );
+                    info!(
+                        service = "trading-engine",
+                        mode = app.mode.as_str(),
+                        watch_id = watch.id,
+                        instrument = watch.instrument.0,
+                        template = watch.template.slug(),
+                        "strategy watch started"
+                    );
                 }
                 StrategyCommand::Stop { watch_id } => {
                     let watch = app.strategy_store.stop_watch(app.mode, watch_id)?;
@@ -200,6 +224,14 @@ impl AppRuntime {
                             "instrument": watch.instrument.0,
                             "state": watch.state.as_str(),
                         }),
+                    );
+                    info!(
+                        service = "trading-engine",
+                        mode = app.mode.as_str(),
+                        watch_id = watch.id,
+                        instrument = watch.instrument.0,
+                        template = watch.template.slug(),
+                        "strategy watch stopped"
                     );
                 }
             },
@@ -222,6 +254,14 @@ impl AppRuntime {
                         "today_funding_pnl_usdt": today_funding_pnl_usdt,
                         "margin_ratio": margin_ratio,
                     }),
+                );
+                info!(
+                    service = "trading-engine",
+                    mode = app.mode.as_str(),
+                    positions = report.positions,
+                    open_order_groups = report.open_order_groups,
+                    balances = report.balances,
+                    "authoritative state refreshed"
                 );
             }
         }
@@ -385,6 +425,42 @@ fn execution_payload(
         _ => json!({
             "command_kind": "unknown",
             "outcome_kind": "unknown",
+        }),
+    }
+}
+
+fn execution_request_payload(command: &ExecutionCommand) -> serde_json::Value {
+    match command {
+        ExecutionCommand::SetTargetExposure {
+            instrument,
+            target,
+            order_type,
+            ..
+        } => json!({
+            "command_kind": "set_target_exposure",
+            "instrument": instrument.0,
+            "target": target.value(),
+            "order_type": format_order_type(*order_type),
+        }),
+        ExecutionCommand::CloseSymbol { instrument, .. } => json!({
+            "command_kind": "close_symbol",
+            "instrument": instrument.0,
+        }),
+        ExecutionCommand::CloseAll { .. } => json!({
+            "command_kind": "close_all",
+        }),
+        ExecutionCommand::SubmitOptionOrder {
+            instrument,
+            side,
+            qty,
+            order_type,
+            ..
+        } => json!({
+            "command_kind": "submit_option_order",
+            "instrument": instrument.0,
+            "side": format!("{side:?}"),
+            "qty": qty,
+            "order_type": format_order_type(*order_type),
         }),
     }
 }

--- a/src/backtest_app/export.rs
+++ b/src/backtest_app/export.rs
@@ -1,0 +1,55 @@
+use crate::backtest_app::runner::BacktestReport;
+use crate::error::storage_error::StorageError;
+use crate::storage::postgres_market_data::{
+    connect as connect_postgres, export_backtest_report, init_schema as init_postgres_schema,
+    postgres_url_from_env,
+};
+
+pub fn maybe_export_report_to_postgres(
+    report: &BacktestReport,
+) -> Result<Option<i64>, StorageError> {
+    if !postgres_export_enabled() {
+        return Ok(None);
+    }
+    let postgres_url = postgres_url_from_env()?;
+    export_report_to_postgres(report, &postgres_url).map(Some)
+}
+
+pub fn export_report_to_postgres(
+    report: &BacktestReport,
+    postgres_url: &str,
+) -> Result<i64, StorageError> {
+    let mut client = connect_postgres(postgres_url)?;
+    let _ = init_postgres_schema(&mut client, postgres_url)?;
+    export_backtest_report(&mut client, report)
+}
+
+fn postgres_export_enabled() -> bool {
+    std::env::var("SANDBOX_QUANT_BACKTEST_EXPORT_POSTGRES")
+        .ok()
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+        .unwrap_or(false)
+        || std::env::var("SANDBOX_QUANT_POSTGRES_URL").is_ok()
+        || std::env::var("DATABASE_URL").is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn postgres_export_enables_with_explicit_flag() {
+        std::env::remove_var("SANDBOX_QUANT_POSTGRES_URL");
+        std::env::remove_var("DATABASE_URL");
+        std::env::set_var("SANDBOX_QUANT_BACKTEST_EXPORT_POSTGRES", "1");
+
+        assert!(postgres_export_enabled());
+
+        std::env::remove_var("SANDBOX_QUANT_BACKTEST_EXPORT_POSTGRES");
+    }
+}

--- a/src/backtest_app/mod.rs
+++ b/src/backtest_app/mod.rs
@@ -1,3 +1,4 @@
+pub mod export;
 pub mod runner;
 pub mod snapshot;
 pub mod terminal;

--- a/src/backtest_app/runner.rs
+++ b/src/backtest_app/runner.rs
@@ -6,9 +6,15 @@ use chrono::{DateTime, TimeZone, Utc};
 use crate::app::bootstrap::BinanceMode;
 use crate::dataset::query::{
     backtest_summary_for_path, load_book_ticker_rows_for_path, load_liquidation_events_for_path,
+    load_raw_kline_rows_for_path,
 };
-use crate::dataset::types::{BacktestDatasetSummary, BookTickerRow, LiquidationEventRow};
+use crate::dataset::types::{
+    BacktestDatasetSummary, BookTickerRow, DerivedKlineRow, LiquidationEventRow,
+};
 use crate::error::storage_error::StorageError;
+use crate::storage::postgres_market_data::{
+    backtest_summary_for_postgres_url, load_raw_kline_rows_for_postgres_url, mask_postgres_url,
+};
 use crate::strategy::model::StrategyTemplate;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -135,6 +141,12 @@ enum ReplayEventKind {
     BookTicker(usize),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PriceCrossDirection {
+    Long,
+    Short,
+}
+
 pub fn run_backtest_for_path(
     db_path: &Path,
     mode: BinanceMode,
@@ -145,20 +157,274 @@ pub fn run_backtest_for_path(
     config: BacktestConfig,
 ) -> Result<BacktestReport, StorageError> {
     let dataset = backtest_summary_for_path(db_path, mode, instrument, from, to)?;
-    let liquidation_events = load_liquidation_events_for_path(db_path, instrument, from, to)?;
-    let book_tickers = load_book_ticker_rows_for_path(db_path, instrument, from, to)?;
-    Ok(run_backtest_on_events(
-        template,
-        instrument.to_string(),
-        mode,
-        from,
-        to,
-        db_path.to_path_buf(),
-        dataset,
-        liquidation_events,
-        book_tickers,
-        config,
-    ))
+    ensure_symbol_found(&dataset, template, instrument)?;
+    match template {
+        StrategyTemplate::LiquidationBreakdownShort => {
+            let liquidation_events =
+                load_liquidation_events_for_path(db_path, instrument, from, to)?;
+            let book_tickers = load_book_ticker_rows_for_path(db_path, instrument, from, to)?;
+            ensure_liquidation_dataset_ready(
+                template,
+                instrument,
+                &dataset,
+                liquidation_events.len(),
+                book_tickers.len(),
+            )?;
+            Ok(run_backtest_on_events(
+                template,
+                instrument.to_string(),
+                mode,
+                from,
+                to,
+                db_path.to_path_buf(),
+                dataset,
+                liquidation_events,
+                book_tickers,
+                config,
+            ))
+        }
+        StrategyTemplate::PriceSmaCrossLong => {
+            let (_, klines) = load_raw_kline_rows_for_path(db_path, instrument, from, to)?
+                .unwrap_or_else(|| ("none".to_string(), Vec::new()));
+            ensure_price_cross_dataset_ready(template, instrument, &dataset, klines.len(), 50)?;
+            Ok(run_price_sma_cross_on_klines(
+                template,
+                PriceCrossDirection::Long,
+                20,
+                50,
+                instrument.to_string(),
+                mode,
+                from,
+                to,
+                db_path.to_path_buf(),
+                dataset,
+                klines,
+                config,
+            ))
+        }
+        StrategyTemplate::PriceSmaCrossShort => {
+            let (_, klines) = load_raw_kline_rows_for_path(db_path, instrument, from, to)?
+                .unwrap_or_else(|| ("none".to_string(), Vec::new()));
+            ensure_price_cross_dataset_ready(template, instrument, &dataset, klines.len(), 50)?;
+            Ok(run_price_sma_cross_on_klines(
+                template,
+                PriceCrossDirection::Short,
+                20,
+                50,
+                instrument.to_string(),
+                mode,
+                from,
+                to,
+                db_path.to_path_buf(),
+                dataset,
+                klines,
+                config,
+            ))
+        }
+        StrategyTemplate::PriceSmaCrossLongFast => {
+            let (_, klines) = load_raw_kline_rows_for_path(db_path, instrument, from, to)?
+                .unwrap_or_else(|| ("none".to_string(), Vec::new()));
+            ensure_price_cross_dataset_ready(template, instrument, &dataset, klines.len(), 21)?;
+            Ok(run_price_sma_cross_on_klines(
+                template,
+                PriceCrossDirection::Long,
+                9,
+                21,
+                instrument.to_string(),
+                mode,
+                from,
+                to,
+                db_path.to_path_buf(),
+                dataset,
+                klines,
+                config,
+            ))
+        }
+        StrategyTemplate::PriceSmaCrossShortFast => {
+            let (_, klines) = load_raw_kline_rows_for_path(db_path, instrument, from, to)?
+                .unwrap_or_else(|| ("none".to_string(), Vec::new()));
+            ensure_price_cross_dataset_ready(template, instrument, &dataset, klines.len(), 21)?;
+            Ok(run_price_sma_cross_on_klines(
+                template,
+                PriceCrossDirection::Short,
+                9,
+                21,
+                instrument.to_string(),
+                mode,
+                from,
+                to,
+                db_path.to_path_buf(),
+                dataset,
+                klines,
+                config,
+            ))
+        }
+    }
+}
+
+pub fn run_backtest_for_postgres_url(
+    postgres_url: &str,
+    mode: BinanceMode,
+    template: StrategyTemplate,
+    instrument: &str,
+    from: chrono::NaiveDate,
+    to: chrono::NaiveDate,
+    config: BacktestConfig,
+) -> Result<BacktestReport, StorageError> {
+    let dataset = backtest_summary_for_postgres_url(postgres_url, mode, instrument, from, to)?;
+    let db_path = PathBuf::from(mask_postgres_url(postgres_url));
+    ensure_symbol_found(&dataset, template, instrument)?;
+    match template {
+        StrategyTemplate::LiquidationBreakdownShort => Err(StorageError::WriteFailedWithContext {
+            message: "liquidation-breakdown-short is not supported in PostgreSQL direct mode yet"
+                .to_string(),
+        }),
+        StrategyTemplate::PriceSmaCrossLong => {
+            let (_, klines) =
+                load_raw_kline_rows_for_postgres_url(postgres_url, mode, instrument, from, to)?
+                    .unwrap_or_else(|| ("none".to_string(), Vec::new()));
+            ensure_price_cross_dataset_ready(template, instrument, &dataset, klines.len(), 50)?;
+            Ok(run_price_sma_cross_on_klines(
+                template,
+                PriceCrossDirection::Long,
+                20,
+                50,
+                instrument.to_string(),
+                mode,
+                from,
+                to,
+                db_path,
+                dataset,
+                klines,
+                config,
+            ))
+        }
+        StrategyTemplate::PriceSmaCrossShort => {
+            let (_, klines) =
+                load_raw_kline_rows_for_postgres_url(postgres_url, mode, instrument, from, to)?
+                    .unwrap_or_else(|| ("none".to_string(), Vec::new()));
+            ensure_price_cross_dataset_ready(template, instrument, &dataset, klines.len(), 50)?;
+            Ok(run_price_sma_cross_on_klines(
+                template,
+                PriceCrossDirection::Short,
+                20,
+                50,
+                instrument.to_string(),
+                mode,
+                from,
+                to,
+                db_path,
+                dataset,
+                klines,
+                config,
+            ))
+        }
+        StrategyTemplate::PriceSmaCrossLongFast => {
+            let (_, klines) =
+                load_raw_kline_rows_for_postgres_url(postgres_url, mode, instrument, from, to)?
+                    .unwrap_or_else(|| ("none".to_string(), Vec::new()));
+            ensure_price_cross_dataset_ready(template, instrument, &dataset, klines.len(), 21)?;
+            Ok(run_price_sma_cross_on_klines(
+                template,
+                PriceCrossDirection::Long,
+                9,
+                21,
+                instrument.to_string(),
+                mode,
+                from,
+                to,
+                db_path,
+                dataset,
+                klines,
+                config,
+            ))
+        }
+        StrategyTemplate::PriceSmaCrossShortFast => {
+            let (_, klines) =
+                load_raw_kline_rows_for_postgres_url(postgres_url, mode, instrument, from, to)?
+                    .unwrap_or_else(|| ("none".to_string(), Vec::new()));
+            ensure_price_cross_dataset_ready(template, instrument, &dataset, klines.len(), 21)?;
+            Ok(run_price_sma_cross_on_klines(
+                template,
+                PriceCrossDirection::Short,
+                9,
+                21,
+                instrument.to_string(),
+                mode,
+                from,
+                to,
+                db_path,
+                dataset,
+                klines,
+                config,
+            ))
+        }
+    }
+}
+
+fn ensure_symbol_found(
+    dataset: &BacktestDatasetSummary,
+    template: StrategyTemplate,
+    instrument: &str,
+) -> Result<(), StorageError> {
+    if dataset.symbol_found {
+        return Ok(());
+    }
+    Err(StorageError::WriteFailedWithContext {
+        message: format!(
+            "backtest failed: template={} instrument={} symbol not found in dataset for range {}..{}",
+            template.slug(),
+            instrument,
+            dataset.from,
+            dataset.to
+        ),
+    })
+}
+
+fn ensure_liquidation_dataset_ready(
+    template: StrategyTemplate,
+    instrument: &str,
+    dataset: &BacktestDatasetSummary,
+    liquidation_count: usize,
+    book_ticker_count: usize,
+) -> Result<(), StorageError> {
+    if liquidation_count > 0 && book_ticker_count > 0 {
+        return Ok(());
+    }
+    Err(StorageError::WriteFailedWithContext {
+        message: format!(
+            "backtest failed: template={} instrument={} insufficient liquidation dataset in range {}..{} (liquidations={} book_tickers={})",
+            template.slug(),
+            instrument,
+            dataset.from,
+            dataset.to,
+            liquidation_count,
+            book_ticker_count
+        ),
+    })
+}
+
+fn ensure_price_cross_dataset_ready(
+    template: StrategyTemplate,
+    instrument: &str,
+    dataset: &BacktestDatasetSummary,
+    kline_count: usize,
+    min_klines: usize,
+) -> Result<(), StorageError> {
+    if kline_count >= min_klines {
+        return Ok(());
+    }
+    Err(StorageError::WriteFailedWithContext {
+        message: format!(
+            "backtest failed: template={} instrument={} insufficient kline rows in range {}..{} (required_at_least={} actual={})",
+            template.slug(),
+            instrument,
+            dataset.from,
+            dataset.to,
+            min_klines,
+            kline_count
+        ),
+    })
 }
 
 fn run_backtest_on_events(
@@ -449,6 +715,329 @@ fn average_net_of(trades: &[BacktestTrade], reason: BacktestExitReason) -> f64 {
     }
 }
 
+fn run_price_sma_cross_on_klines(
+    template: StrategyTemplate,
+    direction: PriceCrossDirection,
+    fast_window: usize,
+    slow_window: usize,
+    instrument: String,
+    mode: BinanceMode,
+    from: chrono::NaiveDate,
+    to: chrono::NaiveDate,
+    db_path: PathBuf,
+    dataset: BacktestDatasetSummary,
+    klines: Vec<DerivedKlineRow>,
+    config: BacktestConfig,
+) -> BacktestReport {
+    let closes = klines.iter().map(|row| row.close).collect::<Vec<_>>();
+    let mut open_trade: Option<OpenTrade> = None;
+    let mut trades = Vec::new();
+    let mut trigger_count = 0usize;
+    let mut skipped_triggers = 0usize;
+    let mut equity = config.starting_equity;
+
+    for index in 0..klines.len() {
+        let Some(fast_now) = simple_moving_average(&closes, fast_window, index) else {
+            continue;
+        };
+        let Some(slow_now) = simple_moving_average(&closes, slow_window, index) else {
+            continue;
+        };
+        let Some(fast_prev) = index
+            .checked_sub(1)
+            .and_then(|value| simple_moving_average(&closes, fast_window, value))
+        else {
+            continue;
+        };
+        let Some(slow_prev) = index
+            .checked_sub(1)
+            .and_then(|value| simple_moving_average(&closes, slow_window, value))
+        else {
+            continue;
+        };
+        let candle = &klines[index];
+
+        if let Some(trade) = open_trade.as_ref() {
+            let stop_hit = match direction {
+                PriceCrossDirection::Long => candle.low <= trade.stop_price,
+                PriceCrossDirection::Short => candle.high >= trade.stop_price,
+            };
+            if stop_hit {
+                let exit_price = match direction {
+                    PriceCrossDirection::Long => {
+                        trade.stop_price * (1.0 - config.stop_slippage_pct)
+                    }
+                    PriceCrossDirection::Short => {
+                        trade.stop_price * (1.0 + config.stop_slippage_pct)
+                    }
+                };
+                let gross_pnl = gross_pnl(direction, trade.entry_price, exit_price, trade.qty);
+                let exit_fee = exit_price * trade.qty * config.taker_fee_rate;
+                let fees = trade.entry_fee + exit_fee;
+                let net_pnl = gross_pnl - fees;
+                equity += net_pnl;
+                trades.push(BacktestTrade {
+                    trade_id: trade.trade_id,
+                    trigger_time: timestamp_utc(trade.trigger_time_ms),
+                    entry_time: timestamp_utc(trade.entry_time_ms),
+                    entry_price: trade.entry_price,
+                    stop_price: trade.stop_price,
+                    take_profit_price: trade.take_profit_price,
+                    qty: trade.qty,
+                    exit_time: Some(timestamp_utc(candle.close_time_ms)),
+                    exit_price: Some(exit_price),
+                    exit_reason: Some(BacktestExitReason::StopLoss),
+                    gross_pnl: Some(gross_pnl),
+                    fees: Some(fees),
+                    net_pnl: Some(net_pnl),
+                });
+                open_trade = None;
+                continue;
+            }
+            let take_profit_hit = match direction {
+                PriceCrossDirection::Long => candle.high >= trade.take_profit_price,
+                PriceCrossDirection::Short => candle.low <= trade.take_profit_price,
+            };
+            if take_profit_hit {
+                let exit_price = match direction {
+                    PriceCrossDirection::Long => {
+                        trade.take_profit_price * (1.0 - config.tp_slippage_pct)
+                    }
+                    PriceCrossDirection::Short => {
+                        trade.take_profit_price * (1.0 + config.tp_slippage_pct)
+                    }
+                };
+                let gross_pnl = gross_pnl(direction, trade.entry_price, exit_price, trade.qty);
+                let exit_fee = exit_price * trade.qty * config.taker_fee_rate;
+                let fees = trade.entry_fee + exit_fee;
+                let net_pnl = gross_pnl - fees;
+                equity += net_pnl;
+                trades.push(BacktestTrade {
+                    trade_id: trade.trade_id,
+                    trigger_time: timestamp_utc(trade.trigger_time_ms),
+                    entry_time: timestamp_utc(trade.entry_time_ms),
+                    entry_price: trade.entry_price,
+                    stop_price: trade.stop_price,
+                    take_profit_price: trade.take_profit_price,
+                    qty: trade.qty,
+                    exit_time: Some(timestamp_utc(candle.close_time_ms)),
+                    exit_price: Some(exit_price),
+                    exit_reason: Some(BacktestExitReason::TakeProfit),
+                    gross_pnl: Some(gross_pnl),
+                    fees: Some(fees),
+                    net_pnl: Some(net_pnl),
+                });
+                open_trade = None;
+                continue;
+            }
+        }
+
+        let cross_up = fast_prev <= slow_prev && fast_now > slow_now;
+        let cross_down = fast_prev >= slow_prev && fast_now < slow_now;
+        let entry_signal = match direction {
+            PriceCrossDirection::Long => cross_up,
+            PriceCrossDirection::Short => cross_down,
+        };
+        let exit_signal = match direction {
+            PriceCrossDirection::Long => cross_down,
+            PriceCrossDirection::Short => cross_up,
+        };
+
+        if open_trade.is_none() {
+            if !entry_signal {
+                continue;
+            }
+            if equity <= 0.0 {
+                skipped_triggers += 1;
+                continue;
+            }
+            let entry_price = match direction {
+                PriceCrossDirection::Long => {
+                    candle.close * (1.0 + config.max_entry_slippage_pct * 0.5)
+                }
+                PriceCrossDirection::Short => {
+                    candle.close * (1.0 - config.max_entry_slippage_pct * 0.5)
+                }
+            };
+            let risk_amount = equity * config.risk_pct;
+            let qty = risk_amount / (entry_price * config.stop_distance_pct);
+            if !(qty.is_finite() && qty > 0.0) {
+                skipped_triggers += 1;
+                continue;
+            }
+            trigger_count += 1;
+            let entry_fee = entry_price * qty * config.taker_fee_rate;
+            open_trade = Some(OpenTrade {
+                trade_id: trades.len() + 1,
+                trigger_time_ms: candle.open_time_ms,
+                entry_time_ms: candle.close_time_ms,
+                entry_price,
+                stop_price: match direction {
+                    PriceCrossDirection::Long => entry_price * (1.0 - config.stop_distance_pct),
+                    PriceCrossDirection::Short => entry_price * (1.0 + config.stop_distance_pct),
+                },
+                take_profit_price: match direction {
+                    PriceCrossDirection::Long => {
+                        entry_price * (1.0 + config.stop_distance_pct * config.r_multiple)
+                    }
+                    PriceCrossDirection::Short => {
+                        entry_price * (1.0 - config.stop_distance_pct * config.r_multiple)
+                    }
+                },
+                qty,
+                entry_fee,
+            });
+            continue;
+        }
+
+        if exit_signal {
+            let trade = open_trade.take().expect("open trade");
+            let exit_price = match direction {
+                PriceCrossDirection::Long => {
+                    candle.close * (1.0 - config.max_entry_slippage_pct * 0.5)
+                }
+                PriceCrossDirection::Short => {
+                    candle.close * (1.0 + config.max_entry_slippage_pct * 0.5)
+                }
+            };
+            let gross_pnl = gross_pnl(direction, trade.entry_price, exit_price, trade.qty);
+            let exit_fee = exit_price * trade.qty * config.taker_fee_rate;
+            let fees = trade.entry_fee + exit_fee;
+            let net_pnl = gross_pnl - fees;
+            equity += net_pnl;
+            trades.push(BacktestTrade {
+                trade_id: trade.trade_id,
+                trigger_time: timestamp_utc(trade.trigger_time_ms),
+                entry_time: timestamp_utc(trade.entry_time_ms),
+                entry_price: trade.entry_price,
+                stop_price: trade.stop_price,
+                take_profit_price: trade.take_profit_price,
+                qty: trade.qty,
+                exit_time: Some(timestamp_utc(candle.close_time_ms)),
+                exit_price: Some(exit_price),
+                exit_reason: Some(BacktestExitReason::SignalExit),
+                gross_pnl: Some(gross_pnl),
+                fees: Some(fees),
+                net_pnl: Some(net_pnl),
+            });
+        }
+    }
+
+    if let Some(trade) = open_trade.take() {
+        if let Some(last) = klines.last() {
+            let exit_price = last.close;
+            let gross_pnl = gross_pnl(direction, trade.entry_price, exit_price, trade.qty);
+            let exit_fee = exit_price * trade.qty * config.taker_fee_rate;
+            let fees = trade.entry_fee + exit_fee;
+            let net_pnl = gross_pnl - fees;
+            equity += net_pnl;
+            trades.push(BacktestTrade {
+                trade_id: trade.trade_id,
+                trigger_time: timestamp_utc(trade.trigger_time_ms),
+                entry_time: timestamp_utc(trade.entry_time_ms),
+                entry_price: trade.entry_price,
+                stop_price: trade.stop_price,
+                take_profit_price: trade.take_profit_price,
+                qty: trade.qty,
+                exit_time: Some(timestamp_utc(last.close_time_ms)),
+                exit_price: Some(exit_price),
+                exit_reason: Some(BacktestExitReason::OpenAtEnd),
+                gross_pnl: Some(gross_pnl),
+                fees: Some(fees),
+                net_pnl: Some(net_pnl),
+            });
+        }
+    }
+
+    let realized = trades
+        .iter()
+        .filter_map(|trade| trade.net_pnl)
+        .collect::<Vec<_>>();
+    let wins = realized.iter().filter(|value| **value > 0.0).count();
+    let losses = realized.iter().filter(|value| **value < 0.0).count();
+    let net_pnl = realized.iter().sum::<f64>();
+    let average_net_pnl = if realized.is_empty() {
+        0.0
+    } else {
+        net_pnl / realized.len() as f64
+    };
+    let observed_win_rate = if realized.is_empty() {
+        0.0
+    } else {
+        wins as f64 / realized.len() as f64
+    };
+    let average_win = average_positive(&realized);
+    let average_loss = average_negative_abs(&realized);
+    let configured_expected_value = config.win_rate_assumption * average_win
+        - (1.0 - config.win_rate_assumption) * average_loss;
+
+    BacktestReport {
+        run_id: None,
+        template,
+        instrument,
+        mode,
+        from,
+        to,
+        db_path,
+        dataset,
+        config: config.clone(),
+        trigger_count,
+        trades,
+        wins,
+        losses,
+        open_trades: 0,
+        skipped_triggers,
+        starting_equity: config.starting_equity,
+        ending_equity: equity,
+        net_pnl,
+        observed_win_rate,
+        average_net_pnl,
+        configured_expected_value,
+    }
+}
+
+fn gross_pnl(direction: PriceCrossDirection, entry_price: f64, exit_price: f64, qty: f64) -> f64 {
+    match direction {
+        PriceCrossDirection::Long => (exit_price - entry_price) * qty,
+        PriceCrossDirection::Short => (entry_price - exit_price) * qty,
+    }
+}
+
+fn simple_moving_average(values: &[f64], window: usize, end_index: usize) -> Option<f64> {
+    if end_index + 1 < window {
+        return None;
+    }
+    let start = end_index + 1 - window;
+    let sum = values[start..=end_index].iter().sum::<f64>();
+    Some(sum / window as f64)
+}
+
+fn average_positive(values: &[f64]) -> f64 {
+    let filtered = values
+        .iter()
+        .copied()
+        .filter(|value| *value > 0.0)
+        .collect::<Vec<_>>();
+    if filtered.is_empty() {
+        0.0
+    } else {
+        filtered.iter().sum::<f64>() / filtered.len() as f64
+    }
+}
+
+fn average_negative_abs(values: &[f64]) -> f64 {
+    let filtered = values
+        .iter()
+        .copied()
+        .filter(|value| *value < 0.0)
+        .collect::<Vec<_>>();
+    if filtered.is_empty() {
+        0.0
+    } else {
+        filtered.iter().map(|value| value.abs()).sum::<f64>() / filtered.len() as f64
+    }
+}
+
 fn timestamp_utc(event_time_ms: i64) -> DateTime<Utc> {
     Utc.timestamp_millis_opt(event_time_ms)
         .single()
@@ -551,5 +1140,161 @@ mod tests {
         assert_eq!(report.wins, 0);
         assert_eq!(report.losses, 1);
         assert!(report.net_pnl < 0.0);
+    }
+
+    #[test]
+    fn price_sma_cross_long_backtest_records_trade_from_klines() {
+        let mut klines = Vec::new();
+        for index in 0..80 {
+            let close = if index < 55 {
+                100.0
+            } else {
+                100.0 + (index - 54) as f64
+            };
+            klines.push(DerivedKlineRow {
+                open_time_ms: index as i64 * 60_000,
+                close_time_ms: index as i64 * 60_000 + 59_000,
+                open: close - 0.5,
+                high: close + 2.0,
+                low: close - 1.0,
+                close,
+                volume: 1000.0,
+                quote_volume: close * 1000.0,
+                trade_count: 100,
+            });
+        }
+
+        let report = run_price_sma_cross_on_klines(
+            StrategyTemplate::PriceSmaCrossLong,
+            PriceCrossDirection::Long,
+            20,
+            50,
+            "BTCUSDT".to_string(),
+            BinanceMode::Demo,
+            chrono::NaiveDate::from_ymd_opt(2026, 3, 13).unwrap(),
+            chrono::NaiveDate::from_ymd_opt(2026, 3, 13).unwrap(),
+            PathBuf::from("/tmp/test.duckdb"),
+            BacktestDatasetSummary {
+                mode: BinanceMode::Demo,
+                symbol: "BTCUSDT".to_string(),
+                symbol_found: true,
+                from: "2026-03-13".to_string(),
+                to: "2026-03-13".to_string(),
+                liquidation_events: 0,
+                book_ticker_events: 0,
+                agg_trade_events: 0,
+                derived_kline_1s_bars: 0,
+            },
+            klines,
+            BacktestConfig::default(),
+        );
+
+        assert!(report.trigger_count >= 1);
+        assert!(!report.trades.is_empty());
+        assert!(report.net_pnl.is_finite());
+    }
+
+    #[test]
+    fn price_sma_cross_short_backtest_records_trade_from_klines() {
+        let mut klines = Vec::new();
+        for index in 0..80 {
+            let close = if index < 55 {
+                200.0
+            } else {
+                200.0 - (index - 54) as f64
+            };
+            klines.push(DerivedKlineRow {
+                open_time_ms: index as i64 * 60_000,
+                close_time_ms: index as i64 * 60_000 + 59_000,
+                open: close + 0.5,
+                high: close + 1.0,
+                low: close - 2.0,
+                close,
+                volume: 1000.0,
+                quote_volume: close * 1000.0,
+                trade_count: 100,
+            });
+        }
+
+        let report = run_price_sma_cross_on_klines(
+            StrategyTemplate::PriceSmaCrossShort,
+            PriceCrossDirection::Short,
+            20,
+            50,
+            "BTCUSDT".to_string(),
+            BinanceMode::Demo,
+            chrono::NaiveDate::from_ymd_opt(2026, 3, 13).unwrap(),
+            chrono::NaiveDate::from_ymd_opt(2026, 3, 13).unwrap(),
+            PathBuf::from("/tmp/test.duckdb"),
+            BacktestDatasetSummary {
+                mode: BinanceMode::Demo,
+                symbol: "BTCUSDT".to_string(),
+                symbol_found: true,
+                from: "2026-03-13".to_string(),
+                to: "2026-03-13".to_string(),
+                liquidation_events: 0,
+                book_ticker_events: 0,
+                agg_trade_events: 0,
+                derived_kline_1s_bars: 0,
+            },
+            klines,
+            BacktestConfig::default(),
+        );
+
+        assert!(report.trigger_count >= 1);
+        assert!(!report.trades.is_empty());
+        assert!(report.net_pnl.is_finite());
+    }
+
+    #[test]
+    fn price_sma_cross_long_fast_backtest_records_trade_from_klines() {
+        let mut klines = Vec::new();
+        for index in 0..60 {
+            let close = if index < 25 {
+                100.0
+            } else {
+                100.0 + (index - 24) as f64 * 0.8
+            };
+            klines.push(DerivedKlineRow {
+                open_time_ms: index as i64 * 60_000,
+                close_time_ms: index as i64 * 60_000 + 59_000,
+                open: close - 0.3,
+                high: close + 1.5,
+                low: close - 0.8,
+                close,
+                volume: 1000.0,
+                quote_volume: close * 1000.0,
+                trade_count: 100,
+            });
+        }
+
+        let report = run_price_sma_cross_on_klines(
+            StrategyTemplate::PriceSmaCrossLongFast,
+            PriceCrossDirection::Long,
+            9,
+            21,
+            "BTCUSDT".to_string(),
+            BinanceMode::Demo,
+            chrono::NaiveDate::from_ymd_opt(2026, 3, 13).unwrap(),
+            chrono::NaiveDate::from_ymd_opt(2026, 3, 13).unwrap(),
+            PathBuf::from("/tmp/test.duckdb"),
+            BacktestDatasetSummary {
+                mode: BinanceMode::Demo,
+                symbol: "BTCUSDT".to_string(),
+                symbol_found: true,
+                from: "2026-03-13".to_string(),
+                to: "2026-03-13".to_string(),
+                liquidation_events: 0,
+                book_ticker_events: 0,
+                agg_trade_events: 0,
+                derived_kline_1s_bars: 0,
+            },
+            klines,
+            BacktestConfig::default(),
+        );
+
+        assert!(report.trigger_count >= 1);
+        assert!(!report.trades.is_empty());
+        assert!(report.net_pnl.is_finite());
     }
 }

--- a/src/backtest_app/terminal.rs
+++ b/src/backtest_app/terminal.rs
@@ -1,4 +1,5 @@
 use crate::app::bootstrap::BinanceMode;
+use crate::backtest_app::export::maybe_export_report_to_postgres;
 use crate::backtest_app::runner::{run_backtest_for_path, BacktestConfig};
 use crate::backtest_app::snapshot::maybe_prepare_snapshot_from_postgres;
 use crate::command::backtest::{
@@ -101,6 +102,11 @@ impl TerminalApp for BacktestTerminal {
                         .map_err(|error| error.to_string())?;
                     let mut report = report;
                     report.run_id = Some(run_id);
+                    if let Some(export_run_id) = maybe_export_report_to_postgres(&report)
+                        .map_err(|error| error.to_string())?
+                    {
+                        eprintln!("postgres export completed: export_run_id={export_run_id}");
+                    }
                     Ok(TerminalEvent::Output(render_backtest_run(&report)))
                 }
                 BacktestCommand::List => {
@@ -110,6 +116,9 @@ impl TerminalApp for BacktestTerminal {
                         .map_err(|error| error.to_string())?;
                     Ok(TerminalEvent::Output(render_backtest_run_list(&runs)))
                 }
+                BacktestCommand::Sweep { .. } => Ok(TerminalEvent::Output(
+                    "backtest sweep\nstate=unsupported_in_terminal\nmessage=run sweep from the CLI, not the interactive terminal".to_string(),
+                )),
                 BacktestCommand::ReportLatest => {
                     let db_path =
                         RecorderCoordination::new(self.base_dir.clone()).db_path(self.mode);

--- a/src/bin/postgres_fx_kline_backfill.rs
+++ b/src/bin/postgres_fx_kline_backfill.rs
@@ -1,0 +1,385 @@
+use anyhow::{Context, Result};
+use chrono::{DateTime, Duration, NaiveDate, NaiveDateTime, TimeZone, Timelike, Utc};
+use reqwest::blocking::Client;
+use sandbox_quant::app::bootstrap::BinanceMode;
+use sandbox_quant::observability::logging::init_logging;
+use sandbox_quant::storage::postgres_market_data::{
+    connect as connect_postgres, init_schema as init_postgres_schema, insert_kline,
+    latest_shared_kline_open_time_ms, postgres_url_from_env, PostgresKlineRecord,
+};
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
+
+const DEFAULT_PAIRS: &[&str] = &["USD/KRW", "JPY/KRW", "EUR/KRW", "CNY/KRW"];
+const DEFAULT_PRODUCT: &str = "fx-twelvedata";
+const DEFAULT_INTERVAL: &str = "1min";
+const DEFAULT_OUTPUT_SIZE: usize = 5_000;
+const DEFAULT_START_DATE: &str = "2023-03-15";
+const DEFAULT_POLL_SECONDS: u64 = 60;
+const DEFAULT_MAX_REQUESTS_PER_MINUTE: u64 = 7;
+const DEFAULT_RATE_LIMIT_SLEEP_SECONDS: u64 = 65;
+
+#[derive(Debug, Deserialize)]
+struct FxResponse {
+    values: Option<Vec<FxBar>>,
+    status: Option<String>,
+    code: Option<u16>,
+    message: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct FxBar {
+    datetime: String,
+    open: String,
+    high: String,
+    low: String,
+    close: String,
+    volume: Option<String>,
+}
+
+fn main() -> Result<()> {
+    dotenvy::dotenv().ok();
+
+    let postgres_url = postgres_url_from_env().context("missing PostgreSQL URL")?;
+    let api_key = std::env::var("TWELVE_DATA_API_KEY")
+        .context("missing TWELVE_DATA_API_KEY for Twelve Data FX backfill")?;
+    let pairs = configured_pairs();
+    let mode = configured_mode();
+    let product = configured_product();
+    let interval = configured_interval();
+    let fallback_start_ms = configured_fallback_start_ms()?;
+    let continuous = configured_continuous();
+    let poll_seconds = configured_poll_seconds();
+    let request_gap = configured_request_gap();
+    let rate_limit_sleep = configured_rate_limit_sleep();
+    init_logging("postgres-fx-backfill", Some(mode.as_str()))?;
+
+    let mut client = connect_postgres(&postgres_url)?;
+    let _ = init_postgres_schema(&mut client, &postgres_url)?;
+    let http = Client::builder()
+        .build()
+        .context("failed to build HTTP client")?;
+
+    info!(service = "postgres-fx-backfill", mode = mode.as_str(), product = product, interval = interval, pairs = %pairs.join(","), continuous, poll_seconds, request_gap_ms = request_gap.as_millis() as u64, "postgres fx kline backfill starting");
+
+    loop {
+        let max_open_time_ms = current_closed_minute_open_ms();
+        let mut cycle_rows = 0u64;
+
+        for pair in &pairs {
+            let inserted = backfill_pair(
+                &http,
+                &mut client,
+                &api_key,
+                mode,
+                &product,
+                &interval,
+                pair,
+                fallback_start_ms,
+                max_open_time_ms,
+                request_gap,
+                rate_limit_sleep,
+            )?;
+            cycle_rows += inserted;
+            info!(
+                service = "postgres-fx-backfill",
+                mode = mode.as_str(),
+                pair = pair,
+                inserted_rows = inserted,
+                "fx pair backfill cycle completed"
+            );
+        }
+
+        info!(
+            service = "postgres-fx-backfill",
+            mode = mode.as_str(),
+            inserted_rows = cycle_rows,
+            "postgres fx kline backfill cycle completed"
+        );
+        if !continuous {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_secs(poll_seconds));
+    }
+
+    info!(
+        service = "postgres-fx-backfill",
+        mode = mode.as_str(),
+        "postgres fx kline backfill stopped"
+    );
+    Ok(())
+}
+
+fn backfill_pair(
+    http: &Client,
+    client: &mut postgres::Client,
+    api_key: &str,
+    mode: BinanceMode,
+    product: &str,
+    interval: &str,
+    pair: &str,
+    fallback_start_ms: i64,
+    max_open_time_ms: i64,
+    request_gap: std::time::Duration,
+    rate_limit_sleep: std::time::Duration,
+) -> Result<u64> {
+    let interval_ms = interval_millis(interval)?;
+    let start_ms = latest_kline_open_time_ms(client, mode, product, pair, "1m")?
+        .map(|value| value + interval_ms)
+        .unwrap_or(fallback_start_ms);
+
+    if start_ms > max_open_time_ms {
+        return Ok(0);
+    }
+
+    let mut query_start_ms = start_ms;
+    let mut inserted_rows = 0u64;
+
+    while query_start_ms <= max_open_time_ms {
+        let query_end_ms =
+            (query_start_ms + interval_ms * (DEFAULT_OUTPUT_SIZE as i64 - 1)).min(max_open_time_ms);
+        let url = format!(
+            "https://api.twelvedata.com/time_series?symbol={symbol}&interval={interval}&start_date={start}&end_date={end}&order=ASC&timezone=UTC&outputsize={outputsize}&apikey={apikey}",
+            symbol = pair,
+            interval = interval,
+            start = format_twelvedata_datetime(query_start_ms)?,
+            end = format_twelvedata_datetime(query_end_ms)?,
+            outputsize = DEFAULT_OUTPUT_SIZE,
+            apikey = api_key
+        );
+        let response = fetch_fx_response(http, &url, pair, request_gap, rate_limit_sleep)?;
+
+        if response.status.as_deref() == Some("error") || response.code.is_some() {
+            anyhow::bail!(
+                "Twelve Data error for {}: {}",
+                pair,
+                response
+                    .message
+                    .unwrap_or_else(|| "unknown Twelve Data error".to_string())
+            );
+        }
+
+        let Some(rows) = response.values else {
+            break;
+        };
+        if rows.is_empty() {
+            break;
+        }
+
+        let mut last_open_time_ms = query_start_ms;
+        for row in rows {
+            let record = parse_fx_bar(mode, product, interval, pair, row)?;
+            last_open_time_ms = record.open_time_ms;
+            if record.open_time_ms < start_ms || record.open_time_ms > max_open_time_ms {
+                continue;
+            }
+            insert_kline(client, &record)?;
+            inserted_rows += 1;
+        }
+
+        let next_start_ms = last_open_time_ms + interval_ms;
+        if next_start_ms <= query_start_ms {
+            break;
+        }
+        query_start_ms = next_start_ms;
+    }
+
+    Ok(inserted_rows)
+}
+
+fn fetch_fx_response(
+    http: &Client,
+    url: &str,
+    pair: &str,
+    request_gap: std::time::Duration,
+    rate_limit_sleep: std::time::Duration,
+) -> Result<FxResponse> {
+    loop {
+        let response = http
+            .get(url)
+            .send()
+            .with_context(|| format!("failed to fetch Twelve Data FX bars for {}", pair))?
+            .error_for_status()
+            .with_context(|| format!("Twelve Data FX HTTP status error for {}", pair))?
+            .json::<FxResponse>()
+            .with_context(|| format!("failed to decode Twelve Data FX response for {}", pair))?;
+        std::thread::sleep(request_gap);
+
+        let rate_limited = response.code == Some(429)
+            || response
+                .message
+                .as_deref()
+                .is_some_and(|message| message.contains("run out of API credits"));
+        if rate_limited {
+            warn!(
+                service = "postgres-fx-backfill",
+                pair = pair,
+                sleep_sec = rate_limit_sleep.as_secs(),
+                "twelvedata rate limit hit"
+            );
+            std::thread::sleep(rate_limit_sleep);
+            continue;
+        }
+        return Ok(response);
+    }
+}
+
+fn latest_kline_open_time_ms(
+    client: &mut postgres::Client,
+    _mode: BinanceMode,
+    product: &str,
+    symbol: &str,
+    interval: &str,
+) -> Result<Option<i64>> {
+    latest_shared_kline_open_time_ms(client, product, symbol, interval)
+        .context("failed to query latest FX kline open_time")
+}
+
+fn parse_fx_bar(
+    _mode: BinanceMode,
+    product: &str,
+    interval: &str,
+    pair: &str,
+    row: FxBar,
+) -> Result<PostgresKlineRecord> {
+    let open_time = NaiveDateTime::parse_from_str(&row.datetime, "%Y-%m-%d %H:%M:%S")
+        .context("failed to parse Twelve Data datetime")?;
+    let open_time_ms = Utc.from_utc_datetime(&open_time).timestamp_millis();
+    let interval_ms = interval_millis(interval)?;
+
+    Ok(PostgresKlineRecord {
+        product: product.to_string(),
+        symbol: pair.to_string(),
+        interval_name: "1m".to_string(),
+        open_time_ms,
+        close_time_ms: open_time_ms + interval_ms - 1,
+        open: row.open.parse::<f64>().context("invalid FX open")?,
+        high: row.high.parse::<f64>().context("invalid FX high")?,
+        low: row.low.parse::<f64>().context("invalid FX low")?,
+        close: row.close.parse::<f64>().context("invalid FX close")?,
+        volume: row
+            .volume
+            .as_deref()
+            .unwrap_or("0")
+            .parse::<f64>()
+            .unwrap_or(0.0),
+        quote_volume: 0.0,
+        trade_count: 0,
+        taker_buy_base_volume: None,
+        taker_buy_quote_volume: None,
+        raw_payload: serde_json::to_string(&row).context("failed to encode FX raw payload")?,
+    })
+}
+
+fn configured_pairs() -> Vec<String> {
+    std::env::var("SANDBOX_QUANT_FX_PAIRS")
+        .ok()
+        .map(|value| {
+            value
+                .split(',')
+                .map(|pair| pair.trim().to_ascii_uppercase())
+                .filter(|pair| !pair.is_empty())
+                .collect::<Vec<_>>()
+        })
+        .filter(|pairs| !pairs.is_empty())
+        .unwrap_or_else(|| DEFAULT_PAIRS.iter().map(|pair| pair.to_string()).collect())
+}
+
+fn configured_mode() -> BinanceMode {
+    match std::env::var("BINANCE_MODE").ok().as_deref() {
+        Some("real") => BinanceMode::Real,
+        _ => BinanceMode::Demo,
+    }
+}
+
+fn configured_product() -> String {
+    std::env::var("SANDBOX_QUANT_FX_PRODUCT").unwrap_or_else(|_| DEFAULT_PRODUCT.to_string())
+}
+
+fn configured_interval() -> String {
+    std::env::var("SANDBOX_QUANT_FX_INTERVAL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_INTERVAL.to_string())
+}
+
+fn configured_continuous() -> bool {
+    matches!(
+        std::env::var("SANDBOX_QUANT_FX_CONTINUOUS").ok().as_deref(),
+        Some("1" | "true" | "yes" | "on")
+    )
+}
+
+fn configured_poll_seconds() -> u64 {
+    std::env::var("SANDBOX_QUANT_FX_POLL_SECONDS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_POLL_SECONDS)
+}
+
+fn configured_request_gap() -> std::time::Duration {
+    let max_requests_per_minute = std::env::var("SANDBOX_QUANT_FX_MAX_REQUESTS_PER_MINUTE")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_MAX_REQUESTS_PER_MINUTE);
+    let gap_ms = ((60_000f64 / max_requests_per_minute as f64).ceil() as u64).max(1_000);
+    std::time::Duration::from_millis(gap_ms)
+}
+
+fn configured_rate_limit_sleep() -> std::time::Duration {
+    let seconds = std::env::var("SANDBOX_QUANT_FX_RATE_LIMIT_SLEEP_SECONDS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_RATE_LIMIT_SLEEP_SECONDS);
+    std::time::Duration::from_secs(seconds)
+}
+
+fn configured_fallback_start_ms() -> Result<i64> {
+    let raw =
+        std::env::var("SANDBOX_QUANT_FX_FROM").unwrap_or_else(|_| DEFAULT_START_DATE.to_string());
+    parse_start_time(&raw)
+}
+
+fn parse_start_time(raw: &str) -> Result<i64> {
+    if let Ok(datetime) = DateTime::parse_from_rfc3339(raw) {
+        return Ok(datetime.timestamp_millis());
+    }
+    if let Ok(date) = NaiveDate::parse_from_str(raw, "%Y-%m-%d") {
+        let datetime = date
+            .and_hms_opt(0, 0, 0)
+            .context("invalid fallback start date")?;
+        return Ok(Utc.from_utc_datetime(&datetime).timestamp_millis());
+    }
+    if let Ok(datetime) = NaiveDateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S") {
+        return Ok(Utc.from_utc_datetime(&datetime).timestamp_millis());
+    }
+    anyhow::bail!("unsupported SANDBOX_QUANT_FX_FROM format: {raw}")
+}
+
+fn interval_millis(interval: &str) -> Result<i64> {
+    match interval {
+        "1min" | "1m" => Ok(Duration::minutes(1).num_milliseconds()),
+        other => anyhow::bail!("unsupported FX interval: {other}"),
+    }
+}
+
+fn current_closed_minute_open_ms() -> i64 {
+    let now = Utc::now();
+    let closed = now
+        .with_second(0)
+        .and_then(|value| value.with_nanosecond(0))
+        .unwrap_or(now)
+        - Duration::minutes(1);
+    closed.timestamp_millis()
+}
+
+fn format_twelvedata_datetime(value_ms: i64) -> Result<String> {
+    let datetime = Utc
+        .timestamp_millis_opt(value_ms)
+        .single()
+        .context("invalid Twelve Data datetime millis")?;
+    Ok(datetime.format("%Y-%m-%d %H:%M:%S").to_string())
+}

--- a/src/bin/postgres_kline_backfill.rs
+++ b/src/bin/postgres_kline_backfill.rs
@@ -1,0 +1,315 @@
+use anyhow::{Context, Result};
+use chrono::{DateTime, Duration, NaiveDate, NaiveDateTime, TimeZone, Timelike, Utc};
+use reqwest::blocking::Client;
+use sandbox_quant::app::bootstrap::BinanceMode;
+use sandbox_quant::observability::logging::init_logging;
+use sandbox_quant::storage::postgres_market_data::{
+    connect as connect_postgres, init_schema as init_postgres_schema, insert_kline,
+    latest_shared_kline_open_time_ms, postgres_url_from_env, PostgresKlineRecord,
+};
+use serde_json::Value;
+use tracing::info;
+
+const DEFAULT_SYMBOLS: &[&str] = &["BTCUSDT", "SOLUSDT", "XRPUSDT", "ETHUSDT"];
+const DEFAULT_PRODUCT: &str = "um";
+const DEFAULT_INTERVAL: &str = "1m";
+const DEFAULT_LIMIT: usize = 1_500;
+const DEFAULT_START_DATE: &str = "2023-03-15";
+const DEFAULT_POLL_SECONDS: u64 = 30;
+
+fn main() -> Result<()> {
+    dotenvy::dotenv().ok();
+
+    let postgres_url = postgres_url_from_env().context("missing PostgreSQL URL")?;
+    let symbols = configured_symbols();
+    let mode = configured_mode();
+    let product = configured_product();
+    let interval = configured_interval();
+    let fallback_start_ms = configured_fallback_start_ms()?;
+    let continuous = configured_continuous();
+    let poll_seconds = configured_poll_seconds();
+    init_logging("postgres-kline-backfill", Some(mode.as_str()))?;
+
+    let mut client = connect_postgres(&postgres_url)?;
+    let _ = init_postgres_schema(&mut client, &postgres_url)?;
+    let http = Client::builder()
+        .build()
+        .context("failed to build HTTP client")?;
+
+    info!(service = "postgres-kline-backfill", mode = mode.as_str(), product = product, interval = interval, symbols = %symbols.join(","), continuous, poll_seconds, "postgres kline backfill starting");
+
+    loop {
+        let now_minute = current_closed_minute_open_ms();
+        let mut cycle_rows = 0u64;
+        for symbol in &symbols {
+            let inserted = backfill_symbol(
+                &http,
+                &mut client,
+                mode,
+                &product,
+                &interval,
+                symbol,
+                fallback_start_ms,
+                now_minute,
+            )?;
+            cycle_rows += inserted;
+            info!(
+                service = "postgres-kline-backfill",
+                mode = mode.as_str(),
+                symbol = symbol,
+                inserted_rows = inserted,
+                "symbol backfill cycle completed"
+            );
+        }
+        info!(
+            service = "postgres-kline-backfill",
+            mode = mode.as_str(),
+            inserted_rows = cycle_rows,
+            "postgres kline backfill cycle completed"
+        );
+        if !continuous {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_secs(poll_seconds));
+    }
+
+    info!(
+        service = "postgres-kline-backfill",
+        mode = mode.as_str(),
+        "postgres kline backfill stopped"
+    );
+    Ok(())
+}
+
+fn backfill_symbol(
+    http: &Client,
+    client: &mut postgres::Client,
+    mode: BinanceMode,
+    product: &str,
+    interval: &str,
+    symbol: &str,
+    fallback_start_ms: i64,
+    max_open_time_ms: i64,
+) -> Result<u64> {
+    let mut start_ms = latest_kline_open_time_ms(client, mode, product, symbol, interval)?
+        .unwrap_or(fallback_start_ms);
+    if start_ms < fallback_start_ms {
+        start_ms = fallback_start_ms;
+    } else {
+        start_ms += interval_millis(interval)?;
+    }
+
+    if start_ms > max_open_time_ms {
+        return Ok(0);
+    }
+
+    let mut inserted_rows = 0u64;
+    let interval_ms = interval_millis(interval)?;
+
+    while start_ms <= max_open_time_ms {
+        let url = format!(
+            "https://fapi.binance.com/fapi/v1/klines?symbol={symbol}&interval={interval}&startTime={start_ms}&limit={DEFAULT_LIMIT}"
+        );
+        let rows = http
+            .get(&url)
+            .send()
+            .with_context(|| format!("failed to fetch klines for {symbol}"))?
+            .error_for_status()
+            .with_context(|| format!("kline HTTP status error for {symbol}"))?
+            .json::<Vec<Vec<Value>>>()
+            .with_context(|| format!("failed to decode kline response for {symbol}"))?;
+
+        if rows.is_empty() {
+            break;
+        }
+
+        let mut last_open_time_ms = start_ms;
+        for row in rows {
+            let record = parse_kline_row(mode, product, symbol, interval, row)?;
+            last_open_time_ms = record.open_time_ms;
+            if record.open_time_ms > max_open_time_ms {
+                break;
+            }
+            insert_kline(client, &record)?;
+            inserted_rows += 1;
+        }
+
+        let next_start_ms = last_open_time_ms + interval_ms;
+        if next_start_ms <= start_ms {
+            break;
+        }
+        start_ms = next_start_ms;
+    }
+
+    Ok(inserted_rows)
+}
+
+fn latest_kline_open_time_ms(
+    client: &mut postgres::Client,
+    _mode: BinanceMode,
+    product: &str,
+    symbol: &str,
+    interval: &str,
+) -> Result<Option<i64>> {
+    latest_shared_kline_open_time_ms(client, product, symbol, interval)
+        .context("failed to query latest kline open_time")
+}
+
+fn parse_kline_row(
+    _mode: BinanceMode,
+    product: &str,
+    symbol: &str,
+    interval: &str,
+    row: Vec<Value>,
+) -> Result<PostgresKlineRecord> {
+    if row.len() < 11 {
+        anyhow::bail!("kline row too short for {symbol}");
+    }
+
+    let open_time_ms = value_as_i64(&row[0])?;
+    let open = value_as_f64(&row[1])?;
+    let high = value_as_f64(&row[2])?;
+    let low = value_as_f64(&row[3])?;
+    let close = value_as_f64(&row[4])?;
+    let volume = value_as_f64(&row[5])?;
+    let close_time_ms = value_as_i64(&row[6])?;
+    let quote_volume = value_as_f64(&row[7])?;
+    let trade_count = value_as_i64(&row[8])?;
+    let taker_buy_base_volume = value_as_optional_f64(&row[9])?;
+    let taker_buy_quote_volume = value_as_optional_f64(&row[10])?;
+
+    Ok(PostgresKlineRecord {
+        product: product.to_string(),
+        symbol: symbol.to_string(),
+        interval_name: interval.to_string(),
+        open_time_ms,
+        close_time_ms,
+        open,
+        high,
+        low,
+        close,
+        volume,
+        quote_volume,
+        trade_count,
+        taker_buy_base_volume,
+        taker_buy_quote_volume,
+        raw_payload: serde_json::to_string(&row).context("failed to encode raw kline payload")?,
+    })
+}
+
+fn value_as_i64(value: &Value) -> Result<i64> {
+    match value {
+        Value::Number(number) => number.as_i64().context("expected integer number"),
+        Value::String(text) => text.parse::<i64>().context("expected integer string"),
+        _ => anyhow::bail!("expected integer value"),
+    }
+}
+
+fn value_as_f64(value: &Value) -> Result<f64> {
+    match value {
+        Value::Number(number) => number.as_f64().context("expected float number"),
+        Value::String(text) => text.parse::<f64>().context("expected float string"),
+        _ => anyhow::bail!("expected float value"),
+    }
+}
+
+fn value_as_optional_f64(value: &Value) -> Result<Option<f64>> {
+    match value {
+        Value::Null => Ok(None),
+        Value::String(text) if text.is_empty() => Ok(None),
+        _ => value_as_f64(value).map(Some),
+    }
+}
+
+fn configured_symbols() -> Vec<String> {
+    std::env::var("SANDBOX_QUANT_BACKFILL_SYMBOLS")
+        .ok()
+        .map(|value| {
+            value
+                .split(',')
+                .map(|symbol| symbol.trim().to_ascii_uppercase())
+                .filter(|symbol| !symbol.is_empty())
+                .collect::<Vec<_>>()
+        })
+        .filter(|symbols| !symbols.is_empty())
+        .unwrap_or_else(|| {
+            DEFAULT_SYMBOLS
+                .iter()
+                .map(|symbol| symbol.to_string())
+                .collect()
+        })
+}
+
+fn configured_mode() -> BinanceMode {
+    match std::env::var("BINANCE_MODE").ok().as_deref() {
+        Some("real") => BinanceMode::Real,
+        _ => BinanceMode::Demo,
+    }
+}
+
+fn configured_product() -> String {
+    std::env::var("SANDBOX_QUANT_BACKFILL_PRODUCT").unwrap_or_else(|_| DEFAULT_PRODUCT.to_string())
+}
+
+fn configured_interval() -> String {
+    std::env::var("SANDBOX_QUANT_BACKFILL_INTERVAL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_INTERVAL.to_string())
+}
+
+fn configured_continuous() -> bool {
+    matches!(
+        std::env::var("SANDBOX_QUANT_BACKFILL_CONTINUOUS")
+            .ok()
+            .as_deref(),
+        Some("1" | "true" | "yes" | "on")
+    )
+}
+
+fn configured_poll_seconds() -> u64 {
+    std::env::var("SANDBOX_QUANT_BACKFILL_POLL_SECONDS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_POLL_SECONDS)
+}
+
+fn configured_fallback_start_ms() -> Result<i64> {
+    let raw = std::env::var("SANDBOX_QUANT_BACKFILL_FROM")
+        .unwrap_or_else(|_| DEFAULT_START_DATE.to_string());
+    parse_start_time(&raw)
+}
+
+fn parse_start_time(raw: &str) -> Result<i64> {
+    if let Ok(datetime) = DateTime::parse_from_rfc3339(raw) {
+        return Ok(datetime.timestamp_millis());
+    }
+    if let Ok(date) = NaiveDate::parse_from_str(raw, "%Y-%m-%d") {
+        let datetime = date
+            .and_hms_opt(0, 0, 0)
+            .context("invalid fallback start date")?;
+        return Ok(Utc.from_utc_datetime(&datetime).timestamp_millis());
+    }
+    if let Ok(datetime) = NaiveDateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S") {
+        return Ok(Utc.from_utc_datetime(&datetime).timestamp_millis());
+    }
+    anyhow::bail!("unsupported SANDBOX_QUANT_BACKFILL_FROM format: {raw}")
+}
+
+fn interval_millis(interval: &str) -> Result<i64> {
+    match interval {
+        "1m" => Ok(Duration::minutes(1).num_milliseconds()),
+        other => anyhow::bail!("unsupported interval: {other}"),
+    }
+}
+
+fn current_closed_minute_open_ms() -> i64 {
+    let now = Utc::now();
+    let closed = now
+        .with_second(0)
+        .and_then(|value| value.with_nanosecond(0))
+        .unwrap_or(now)
+        - Duration::minutes(1);
+    closed.timestamp_millis()
+}

--- a/src/bin/postgres_kr_exchange_kline_backfill.rs
+++ b/src/bin/postgres_kr_exchange_kline_backfill.rs
@@ -1,0 +1,447 @@
+use anyhow::{Context, Result};
+use chrono::{DateTime, Duration, FixedOffset, NaiveDate, NaiveDateTime, TimeZone, Timelike, Utc};
+use reqwest::blocking::Client;
+use sandbox_quant::app::bootstrap::BinanceMode;
+use sandbox_quant::observability::logging::init_logging;
+use sandbox_quant::storage::postgres_market_data::{
+    connect as connect_postgres, init_schema as init_postgres_schema, insert_kline,
+    latest_shared_kline_open_time_ms, postgres_url_from_env, PostgresKlineRecord,
+};
+use serde::{Deserialize, Serialize};
+use std::time::Duration as StdDuration;
+use tracing::{info, warn};
+
+const DEFAULT_ASSETS: &[&str] = &["BTC", "SOL", "XRP", "ETH"];
+const DEFAULT_INTERVAL: &str = "1m";
+const DEFAULT_COUNT: usize = 200;
+const DEFAULT_START_DATE: &str = "2023-03-15";
+const DEFAULT_POLL_SECONDS: u64 = 30;
+const DEFAULT_REQUEST_GAP_MS: u64 = 150;
+const DEFAULT_RATE_LIMIT_SLEEP_SECONDS: u64 = 3;
+
+#[derive(Debug, Clone, Copy)]
+struct ExchangeSpec {
+    name: &'static str,
+    market_all_url: &'static str,
+    candles_base_url: &'static str,
+    product: &'static str,
+    cursor_timezone: CursorTimezone,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CursorTimezone {
+    UtcZulu,
+    KstNaive,
+}
+
+#[derive(Debug, Deserialize)]
+struct MarketCode {
+    market: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct KrCandle {
+    market: String,
+    candle_date_time_utc: String,
+    opening_price: f64,
+    high_price: f64,
+    low_price: f64,
+    trade_price: f64,
+    candle_acc_trade_price: f64,
+    candle_acc_trade_volume: f64,
+    unit: u32,
+}
+
+const EXCHANGES: &[ExchangeSpec] = &[
+    ExchangeSpec {
+        name: "upbit",
+        market_all_url: "https://api.upbit.com/v1/market/all?isDetails=false",
+        candles_base_url: "https://api.upbit.com/v1/candles/minutes",
+        product: "upbit-krw",
+        cursor_timezone: CursorTimezone::UtcZulu,
+    },
+    ExchangeSpec {
+        name: "bithumb",
+        market_all_url: "https://api.bithumb.com/v1/market/all?isDetails=false",
+        candles_base_url: "https://api.bithumb.com/v1/candles/minutes",
+        product: "bithumb-krw",
+        cursor_timezone: CursorTimezone::KstNaive,
+    },
+];
+
+fn main() -> Result<()> {
+    dotenvy::dotenv().ok();
+
+    let postgres_url = postgres_url_from_env().context("missing PostgreSQL URL")?;
+    let assets = configured_assets();
+    let mode = configured_mode();
+    let interval = configured_interval();
+    let fallback_start_ms = configured_fallback_start_ms()?;
+    let continuous = configured_continuous();
+    let poll_seconds = configured_poll_seconds();
+    let request_gap = configured_request_gap();
+    let rate_limit_sleep = configured_rate_limit_sleep();
+    init_logging("postgres-kr-backfill", Some(mode.as_str()))?;
+
+    let mut client = connect_postgres(&postgres_url)?;
+    let _ = init_postgres_schema(&mut client, &postgres_url)?;
+    let http = Client::builder()
+        .build()
+        .context("failed to build HTTP client")?;
+
+    info!(service = "postgres-kr-backfill", mode = mode.as_str(), interval = interval, assets = %assets.join(","), continuous, poll_seconds, "postgres kr exchange kline backfill starting");
+
+    let market_maps = EXCHANGES
+        .iter()
+        .map(|exchange| {
+            let markets = fetch_markets(&http, exchange)?;
+            Ok::<_, anyhow::Error>((exchange.name, markets))
+        })
+        .collect::<Result<std::collections::BTreeMap<_, _>>>()?;
+
+    loop {
+        let max_open_time_ms = current_closed_minute_open_ms();
+        let mut cycle_rows = 0u64;
+
+        for exchange in EXCHANGES {
+            let markets = market_maps
+                .get(exchange.name)
+                .context("missing exchange market map")?;
+            for asset in &assets {
+                let market = resolve_market(markets, asset).with_context(|| {
+                    format!("{} market missing for asset {}", exchange.name, asset)
+                })?;
+                let inserted = backfill_market(
+                    &http,
+                    &mut client,
+                    mode,
+                    exchange,
+                    &interval,
+                    market,
+                    fallback_start_ms,
+                    max_open_time_ms,
+                    request_gap,
+                    rate_limit_sleep,
+                )?;
+                cycle_rows += inserted;
+                info!(
+                    service = "postgres-kr-backfill",
+                    mode = mode.as_str(),
+                    exchange = exchange.name,
+                    market = market,
+                    inserted_rows = inserted,
+                    "market backfill cycle completed"
+                );
+            }
+        }
+
+        info!(
+            service = "postgres-kr-backfill",
+            mode = mode.as_str(),
+            inserted_rows = cycle_rows,
+            "postgres kr exchange kline backfill cycle completed"
+        );
+        if !continuous {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_secs(poll_seconds));
+    }
+
+    info!(
+        service = "postgres-kr-backfill",
+        mode = mode.as_str(),
+        "postgres kr exchange kline backfill stopped"
+    );
+    Ok(())
+}
+
+fn fetch_markets(http: &Client, exchange: &ExchangeSpec) -> Result<Vec<String>> {
+    let rows = http
+        .get(exchange.market_all_url)
+        .send()
+        .with_context(|| format!("failed to fetch {} market list", exchange.name))?
+        .error_for_status()
+        .with_context(|| format!("{} market list HTTP status error", exchange.name))?
+        .json::<Vec<MarketCode>>()
+        .with_context(|| format!("failed to decode {} market list", exchange.name))?;
+    Ok(rows.into_iter().map(|row| row.market).collect())
+}
+
+fn resolve_market<'a>(markets: &'a [String], asset: &str) -> Option<&'a str> {
+    let target = format!("KRW-{}", asset.to_ascii_uppercase());
+    markets
+        .iter()
+        .find(|market| market.as_str() == target)
+        .map(String::as_str)
+}
+
+fn backfill_market(
+    http: &Client,
+    client: &mut postgres::Client,
+    mode: BinanceMode,
+    exchange: &ExchangeSpec,
+    interval: &str,
+    market: &str,
+    fallback_start_ms: i64,
+    max_open_time_ms: i64,
+    request_gap: StdDuration,
+    rate_limit_sleep: StdDuration,
+) -> Result<u64> {
+    let interval_ms = interval_millis(interval)?;
+    let start_ms = latest_kline_open_time_ms(client, mode, exchange.product, market, interval)?
+        .map(|value| value + interval_ms)
+        .unwrap_or(fallback_start_ms);
+
+    if start_ms > max_open_time_ms {
+        return Ok(0);
+    }
+
+    let mut cursor_ms = max_open_time_ms + interval_ms;
+    let mut inserted_rows = 0u64;
+
+    while cursor_ms > start_ms {
+        let url = format!(
+            "{}/{unit}?market={market}&to={to}&count={count}",
+            exchange.candles_base_url,
+            unit = 1,
+            to = format_cursor(cursor_ms, exchange.cursor_timezone)?,
+            count = DEFAULT_COUNT
+        );
+        let mut rows = fetch_exchange_candles(
+            http,
+            &url,
+            exchange.name,
+            market,
+            request_gap,
+            rate_limit_sleep,
+        )?;
+
+        if rows.is_empty() {
+            break;
+        }
+
+        rows.reverse();
+        let mut oldest_open_time_ms = cursor_ms - interval_ms;
+        for row in rows {
+            let record = parse_candle_row(mode, exchange.product, interval, row)?;
+            oldest_open_time_ms = record.open_time_ms;
+            if record.open_time_ms < start_ms {
+                continue;
+            }
+            if record.open_time_ms > max_open_time_ms {
+                continue;
+            }
+            insert_kline(client, &record)?;
+            inserted_rows += 1;
+        }
+
+        if oldest_open_time_ms <= start_ms {
+            break;
+        }
+        cursor_ms = oldest_open_time_ms;
+    }
+
+    Ok(inserted_rows)
+}
+
+fn fetch_exchange_candles(
+    http: &Client,
+    url: &str,
+    exchange_name: &str,
+    market: &str,
+    request_gap: StdDuration,
+    rate_limit_sleep: StdDuration,
+) -> Result<Vec<KrCandle>> {
+    loop {
+        let response = http
+            .get(url)
+            .send()
+            .with_context(|| format!("failed to fetch {} candles for {}", exchange_name, market))?;
+        let status = response.status();
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            warn!(
+                service = "postgres-kr-backfill",
+                exchange = exchange_name,
+                market = market,
+                sleep_sec = rate_limit_sleep.as_secs(),
+                "exchange rate limit hit"
+            );
+            std::thread::sleep(rate_limit_sleep);
+            continue;
+        }
+        let rows = response
+            .error_for_status()
+            .with_context(|| format!("{} candle HTTP status error for {}", exchange_name, market))?
+            .json::<Vec<KrCandle>>()
+            .with_context(|| {
+                format!("failed to decode {} candles for {}", exchange_name, market)
+            })?;
+        std::thread::sleep(request_gap);
+        return Ok(rows);
+    }
+}
+
+fn latest_kline_open_time_ms(
+    client: &mut postgres::Client,
+    _mode: BinanceMode,
+    product: &str,
+    symbol: &str,
+    interval: &str,
+) -> Result<Option<i64>> {
+    latest_shared_kline_open_time_ms(client, product, symbol, interval)
+        .context("failed to query latest kline open_time")
+}
+
+fn parse_candle_row(
+    _mode: BinanceMode,
+    product: &str,
+    interval: &str,
+    row: KrCandle,
+) -> Result<PostgresKlineRecord> {
+    let open_time = NaiveDateTime::parse_from_str(&row.candle_date_time_utc, "%Y-%m-%dT%H:%M:%S")
+        .context("failed to parse candle_date_time_utc")?;
+    let open_time_ms = Utc.from_utc_datetime(&open_time).timestamp_millis();
+    let interval_ms = interval_millis(interval)?;
+
+    Ok(PostgresKlineRecord {
+        product: product.to_string(),
+        symbol: row.market.clone(),
+        interval_name: interval.to_string(),
+        open_time_ms,
+        close_time_ms: open_time_ms + interval_ms - 1,
+        open: row.opening_price,
+        high: row.high_price,
+        low: row.low_price,
+        close: row.trade_price,
+        volume: row.candle_acc_trade_volume,
+        quote_volume: row.candle_acc_trade_price,
+        trade_count: 0,
+        taker_buy_base_volume: None,
+        taker_buy_quote_volume: None,
+        raw_payload: serde_json::to_string(&row).context("failed to encode raw candle payload")?,
+    })
+}
+
+fn configured_assets() -> Vec<String> {
+    std::env::var("SANDBOX_QUANT_KR_BACKFILL_ASSETS")
+        .ok()
+        .map(|value| {
+            value
+                .split(',')
+                .map(|asset| asset.trim().to_ascii_uppercase())
+                .filter(|asset| !asset.is_empty())
+                .collect::<Vec<_>>()
+        })
+        .filter(|assets| !assets.is_empty())
+        .unwrap_or_else(|| {
+            DEFAULT_ASSETS
+                .iter()
+                .map(|asset| asset.to_string())
+                .collect()
+        })
+}
+
+fn configured_mode() -> BinanceMode {
+    match std::env::var("BINANCE_MODE").ok().as_deref() {
+        Some("real") => BinanceMode::Real,
+        _ => BinanceMode::Demo,
+    }
+}
+
+fn configured_interval() -> String {
+    std::env::var("SANDBOX_QUANT_KR_BACKFILL_INTERVAL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_INTERVAL.to_string())
+}
+
+fn configured_continuous() -> bool {
+    matches!(
+        std::env::var("SANDBOX_QUANT_KR_BACKFILL_CONTINUOUS")
+            .ok()
+            .as_deref(),
+        Some("1" | "true" | "yes" | "on")
+    )
+}
+
+fn configured_poll_seconds() -> u64 {
+    std::env::var("SANDBOX_QUANT_KR_BACKFILL_POLL_SECONDS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_POLL_SECONDS)
+}
+
+fn configured_request_gap() -> StdDuration {
+    let millis = std::env::var("SANDBOX_QUANT_KR_BACKFILL_REQUEST_GAP_MS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_REQUEST_GAP_MS);
+    StdDuration::from_millis(millis)
+}
+
+fn configured_rate_limit_sleep() -> StdDuration {
+    let seconds = std::env::var("SANDBOX_QUANT_KR_BACKFILL_RATE_LIMIT_SLEEP_SECONDS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_RATE_LIMIT_SLEEP_SECONDS);
+    StdDuration::from_secs(seconds)
+}
+
+fn configured_fallback_start_ms() -> Result<i64> {
+    let raw = std::env::var("SANDBOX_QUANT_KR_BACKFILL_FROM")
+        .unwrap_or_else(|_| DEFAULT_START_DATE.to_string());
+    parse_start_time(&raw)
+}
+
+fn parse_start_time(raw: &str) -> Result<i64> {
+    if let Ok(datetime) = DateTime::parse_from_rfc3339(raw) {
+        return Ok(datetime.timestamp_millis());
+    }
+    if let Ok(date) = NaiveDate::parse_from_str(raw, "%Y-%m-%d") {
+        let datetime = date
+            .and_hms_opt(0, 0, 0)
+            .context("invalid fallback start date")?;
+        return Ok(Utc.from_utc_datetime(&datetime).timestamp_millis());
+    }
+    if let Ok(datetime) = NaiveDateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S") {
+        return Ok(Utc.from_utc_datetime(&datetime).timestamp_millis());
+    }
+    anyhow::bail!("unsupported SANDBOX_QUANT_KR_BACKFILL_FROM format: {raw}")
+}
+
+fn interval_millis(interval: &str) -> Result<i64> {
+    match interval {
+        "1m" => Ok(Duration::minutes(1).num_milliseconds()),
+        other => anyhow::bail!("unsupported interval: {other}"),
+    }
+}
+
+fn current_closed_minute_open_ms() -> i64 {
+    let now = Utc::now();
+    let closed = now
+        .with_second(0)
+        .and_then(|value| value.with_nanosecond(0))
+        .unwrap_or(now)
+        - Duration::minutes(1);
+    closed.timestamp_millis()
+}
+
+fn format_cursor(cursor_ms: i64, timezone: CursorTimezone) -> Result<String> {
+    let datetime = Utc
+        .timestamp_millis_opt(cursor_ms)
+        .single()
+        .context("invalid cursor timestamp")?;
+    match timezone {
+        CursorTimezone::UtcZulu => Ok(datetime.format("%Y-%m-%dT%H:%M:%SZ").to_string()),
+        CursorTimezone::KstNaive => {
+            let kst = FixedOffset::east_opt(9 * 3600).context("invalid KST offset")?;
+            Ok(datetime
+                .with_timezone(&kst)
+                .format("%Y-%m-%dT%H:%M:%S")
+                .to_string())
+        }
+    }
+}

--- a/src/bin/sandbox-quant-backtest.rs
+++ b/src/bin/sandbox-quant-backtest.rs
@@ -1,42 +1,57 @@
 use sandbox_quant::app::bootstrap::BinanceMode;
-use sandbox_quant::backtest_app::runner::{run_backtest_for_path, BacktestConfig};
+use sandbox_quant::backtest_app::export::{export_report_to_postgres, maybe_export_report_to_postgres};
+use sandbox_quant::backtest_app::runner::{
+    run_backtest_for_path, run_backtest_for_postgres_url, BacktestConfig,
+};
 use sandbox_quant::backtest_app::snapshot::maybe_prepare_snapshot_from_postgres;
 use sandbox_quant::backtest_app::terminal::BacktestTerminal;
-use sandbox_quant::command::backtest::{parse_backtest_command, BacktestCommand};
+use sandbox_quant::command::backtest::{parse_backtest_command, BacktestCommand, BacktestSweepWindow};
 use sandbox_quant::dataset::query::{
     load_backtest_report, load_backtest_run_summaries, persist_backtest_report,
 };
 use sandbox_quant::dataset::schema::init_schema_for_path;
+use sandbox_quant::observability::logging::init_logging;
 use sandbox_quant::record::coordination::RecorderCoordination;
-use sandbox_quant::storage::postgres_market_data::{
-    export_backtest_report_to_postgres, postgres_url_from_env,
-};
+use sandbox_quant::storage::postgres_market_data::postgres_url_from_env;
 use sandbox_quant::terminal::loop_shell::run_terminal;
 use sandbox_quant::ui::backtest_output::{render_backtest_run, render_backtest_run_list};
+use tracing::{error, info, warn};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = std::env::args().skip(1).collect();
-    if args.is_empty() {
+    let init_mode = args
+        .windows(2)
+        .find(|window| window[0] == "--mode")
+        .map(|window| window[1].as_str())
+        .unwrap_or("demo");
+    init_logging("backtest", Some(init_mode))?;
+    info!(service = "backtest", mode = init_mode, args = ?args, "process started");
+
+    let result: Result<(), Box<dyn std::error::Error>> = if args.is_empty() {
         let mut terminal = BacktestTerminal::new(BinanceMode::Demo, "var");
-        return run_terminal(&mut terminal);
+        run_terminal(&mut terminal)
+    } else {
+        match args.first().map(String::as_str) {
+            Some("run") | Some("sweep") | Some("list") | Some("report") => {
+                run_backtest_command(&args)
+            }
+            Some("--mode") | Some("--base-dir") => {
+                let (mode, base_dir) = parse_terminal_args(&args)?;
+                let mut terminal = BacktestTerminal::new(mode, base_dir);
+                run_terminal(&mut terminal)
+            }
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "usage: sandbox-quant-backtest run <template> <instrument> --from <YYYY-MM-DD> --to <YYYY-MM-DD> [--mode <demo|real>] [--base-dir <path>]\n       sandbox-quant-backtest sweep --templates <csv> --instruments <csv> --windows <from:to,...> [--output-dir <path>] [--mode <demo|real>] [--base-dir <path>]\n       sandbox-quant-backtest list [--mode <demo|real>] [--base-dir <path>]\n       sandbox-quant-backtest report latest|show <run_id> [--mode <demo|real>] [--base-dir <path>]",
+            )
+            .into()),
+        }
+    };
+    if let Err(error) = result {
+        error!(service = "backtest", mode = init_mode, error = %error, "process failed");
+        return Err(error);
     }
-    match args.first().map(String::as_str) {
-        Some("run") | Some("list") | Some("report") => run_backtest_command(&args)?,
-        Some("export") if args.get(1).map(String::as_str) == Some("postgres") => {
-            run_backtest_export_postgres_command(&args[2..])?
-        }
-        Some("--mode") | Some("--base-dir") => {
-            let (mode, base_dir) = parse_terminal_args(&args)?;
-            let mut terminal = BacktestTerminal::new(mode, base_dir);
-            run_terminal(&mut terminal)?;
-        }
-        _ => {
-            eprintln!(
-                "usage: sandbox-quant-backtest run <template> <instrument> --from <YYYY-MM-DD> --to <YYYY-MM-DD> [--mode <demo|real>] [--base-dir <path>]\n       sandbox-quant-backtest list [--mode <demo|real>] [--base-dir <path>]\n       sandbox-quant-backtest report latest|show <run_id> [--mode <demo|real>] [--base-dir <path>]\n       sandbox-quant-backtest export postgres latest|show <run_id> [--mode <demo|real>] [--base-dir <path>] [--postgres-url <url>]"
-            );
-            std::process::exit(2);
-        }
-    }
+    info!(service = "backtest", mode = init_mode, "process completed");
     Ok(())
 }
 
@@ -79,9 +94,33 @@ fn run_backtest_command(args: &[String]) -> Result<(), Box<dyn std::error::Error
             from,
             to,
         } => {
+            if backtest_source_is_postgres() {
+                let postgres_url = postgres_url_from_env()?;
+                let report = run_backtest_for_postgres_url(
+                    &postgres_url,
+                    mode,
+                    template,
+                    &instrument,
+                    from,
+                    to,
+                    BacktestConfig::default(),
+                )?;
+                let export_run_id = maybe_export_report_to_postgres(&report)?
+                    .ok_or("PostgreSQL direct mode expected PostgreSQL export to succeed")?;
+                info!(
+                    service = "backtest",
+                    mode = mode.as_str(),
+                    export_run_id,
+                    "postgres export completed"
+                );
+                eprintln!("postgres export completed: export_run_id={export_run_id}");
+                println!("{}", render_backtest_run(&report));
+                return Ok(());
+            }
             if let Some(message) =
                 maybe_prepare_snapshot_from_postgres(mode, &base_dir, &instrument, from, to)?
             {
+                warn!(service = "backtest", mode = mode.as_str(), instrument = instrument, from = %from, to = %to, message = %message, "snapshot preparation message");
                 eprintln!("{message}");
             }
             init_schema_for_path(&db_path)?;
@@ -97,11 +136,41 @@ fn run_backtest_command(args: &[String]) -> Result<(), Box<dyn std::error::Error
             let run_id = persist_backtest_report(&db_path, &report)?;
             let mut report = report;
             report.run_id = Some(run_id);
+            if let Some(export_run_id) = maybe_export_report_to_postgres(&report)? {
+                info!(
+                    service = "backtest",
+                    mode = mode.as_str(),
+                    export_run_id,
+                    "postgres export completed"
+                );
+                eprintln!("postgres export completed: export_run_id={export_run_id}");
+            }
             println!("{}", render_backtest_run(&report));
         }
         BacktestCommand::List => {
             let runs = load_backtest_run_summaries(&db_path, 20)?;
             println!("{}", render_backtest_run_list(&runs));
+        }
+        BacktestCommand::Sweep {
+            templates,
+            instruments,
+            windows,
+            output_dir,
+        } => {
+            let postgres_url = postgres_url_from_env()?;
+            let sweep = run_backtest_sweep(
+                &postgres_url,
+                mode,
+                &base_dir,
+                templates,
+                instruments,
+                windows,
+                &output_dir,
+            )?;
+            println!("backtest sweep");
+            println!("summary_path={}", sweep.summary_path.display());
+            println!("raw_log_path={}", sweep.raw_log_path.display());
+            println!("runs={}", sweep.rows.len());
         }
         BacktestCommand::ReportLatest => {
             if let Some(report) = load_backtest_report(&db_path, None)? {
@@ -121,51 +190,171 @@ fn run_backtest_command(args: &[String]) -> Result<(), Box<dyn std::error::Error
     Ok(())
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum BacktestExportSelection {
-    Latest,
-    Show(i64),
+#[derive(Debug)]
+struct SweepRow {
+    template: String,
+    instrument: String,
+    from: chrono::NaiveDate,
+    to: chrono::NaiveDate,
+    export_run_id: Option<i64>,
+    state: String,
+    note: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct BacktestExportPostgresConfig {
+#[derive(Debug)]
+struct SweepReport {
+    summary_path: std::path::PathBuf,
+    raw_log_path: std::path::PathBuf,
+    rows: Vec<SweepRow>,
+}
+
+fn run_backtest_sweep(
+    postgres_url: &str,
     mode: BinanceMode,
-    base_dir: String,
-    postgres_url: Option<String>,
-    selection: BacktestExportSelection,
+    base_dir: &str,
+    templates: Vec<sandbox_quant::strategy::model::StrategyTemplate>,
+    instruments: Vec<String>,
+    windows: Vec<BacktestSweepWindow>,
+    output_dir: &str,
+) -> Result<SweepReport, Box<dyn std::error::Error>> {
+    let timestamp = chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
+    let run_dir = std::path::PathBuf::from(output_dir).join(&timestamp);
+    std::fs::create_dir_all(&run_dir)?;
+    let summary_path = run_dir.join("summary.md");
+    let raw_log_path = run_dir.join("runs.log");
+    let mut summary = String::new();
+    summary.push_str("# Backtest Sweep\n\n");
+    summary.push_str(&format!("- timestamp: `{timestamp}`\n"));
+    summary.push_str(&format!("- mode: `{}`\n", mode.as_str()));
+    summary.push_str(&format!("- base_dir: `{base_dir}`\n"));
+    summary.push_str("- postgres_url: `postgres://***`\n\n");
+    summary.push_str("| template | instrument | from | to | export_run_id | state | note |\n");
+    summary.push_str("| --- | --- | --- | --- | --- | --- | --- |\n");
+
+    let mut raw_log = String::new();
+    let mut rows = Vec::new();
+
+    for template in templates {
+        for instrument in &instruments {
+            for window in &windows {
+                let (report, export_run_id) = execute_backtest_run_with_export(
+                    postgres_url,
+                    mode,
+                    base_dir,
+                    template,
+                    instrument,
+                    window.from,
+                    window.to,
+                )?;
+                let rendered = render_backtest_run(&report);
+                let state = rendered
+                    .lines()
+                    .find_map(|line| line.strip_prefix("state="))
+                    .unwrap_or("unknown")
+                    .to_string();
+                raw_log.push_str(&format!(
+                    "=== {} | {} | {} -> {} ===\n{}\nexport_run_id={}\n\n",
+                    template.slug(),
+                    instrument,
+                    window.from,
+                    window.to,
+                    rendered,
+                    export_run_id
+                ));
+                let row = SweepRow {
+                    template: template.slug().to_string(),
+                    instrument: instrument.clone(),
+                    from: window.from,
+                    to: window.to,
+                    export_run_id: Some(export_run_id),
+                    state: state.clone(),
+                    note: "ok".to_string(),
+                };
+                summary.push_str(&format!(
+                    "| {} | {} | {} | {} | {} | {} | {} |\n",
+                    row.template,
+                    row.instrument,
+                    row.from,
+                    row.to,
+                    row.export_run_id
+                        .map(|value| value.to_string())
+                        .unwrap_or_else(|| "n/a".to_string()),
+                    row.state,
+                    row.note
+                ));
+                rows.push(row);
+            }
+        }
+    }
+
+    summary.push_str(
+        "\nGrafana reads the exported runs from `backtest_runs`, `backtest_trades`, and `backtest_equity_points`.\n",
+    );
+    summary.push_str(
+        "Use the `sandbox-quant backtest pnl` dashboard to inspect the exported `export_run_id` values.\n",
+    );
+
+    std::fs::write(&summary_path, summary)?;
+    std::fs::write(&raw_log_path, raw_log)?;
+
+    Ok(SweepReport {
+        summary_path,
+        raw_log_path,
+        rows,
+    })
 }
 
-fn run_backtest_export_postgres_command(
-    args: &[String],
-) -> Result<(), Box<dyn std::error::Error>> {
-    let config = parse_export_postgres_args(args)?;
-    let db_path = RecorderCoordination::new(config.base_dir.clone()).db_path(config.mode);
-    let report = match config.selection {
-        BacktestExportSelection::Latest => load_backtest_report(&db_path, None)?,
-        BacktestExportSelection::Show(run_id) => load_backtest_report(&db_path, Some(run_id))?,
-    };
-    let Some(report) = report else {
-        println!("backtest export\nstate=missing\ntarget=postgres");
-        return Ok(());
-    };
-    let postgres_url = match config.postgres_url {
-        Some(url) => url,
-        None => postgres_url_from_env()?,
-    };
-    let export = export_backtest_report_to_postgres(&postgres_url, &report)?;
-    println!(
-        "{}",
-        [
-            "backtest export".to_string(),
-            "target=postgres".to_string(),
-            format!("source_run_id={}", export.source_run_id),
-            format!("export_run_id={}", export.export_run_id),
-            format!("trade_rows={}", export.trade_rows),
-            format!("equity_point_rows={}", export.equity_point_rows),
-        ]
-        .join("\n")
-    );
-    Ok(())
+fn execute_backtest_run_with_export(
+    postgres_url: &str,
+    mode: BinanceMode,
+    base_dir: &str,
+    template: sandbox_quant::strategy::model::StrategyTemplate,
+    instrument: &str,
+    from: chrono::NaiveDate,
+    to: chrono::NaiveDate,
+) -> Result<(sandbox_quant::backtest_app::runner::BacktestReport, i64), Box<dyn std::error::Error>>
+{
+    if backtest_source_is_postgres() {
+        let report = run_backtest_for_postgres_url(
+            postgres_url,
+            mode,
+            template,
+            instrument,
+            from,
+            to,
+            BacktestConfig::default(),
+        )?;
+        let export_run_id = export_report_to_postgres(&report, postgres_url)?;
+        return Ok((report, export_run_id));
+    }
+
+    if let Some(message) = maybe_prepare_snapshot_from_postgres(mode, base_dir, instrument, from, to)?
+    {
+        eprintln!("{message}");
+    }
+    let db_path = RecorderCoordination::new(base_dir.to_string()).db_path(mode);
+    init_schema_for_path(&db_path)?;
+    let report = run_backtest_for_path(
+        &db_path,
+        mode,
+        template,
+        instrument,
+        from,
+        to,
+        BacktestConfig::default(),
+    )?;
+    let run_id = persist_backtest_report(&db_path, &report)?;
+    let mut report = report;
+    report.run_id = Some(run_id);
+    let export_run_id = export_report_to_postgres(&report, postgres_url)?;
+    Ok((report, export_run_id))
+}
+
+fn backtest_source_is_postgres() -> bool {
+    std::env::var("SANDBOX_QUANT_BACKTEST_SOURCE")
+        .ok()
+        .map(|value| value.trim().eq_ignore_ascii_case("postgres"))
+        .unwrap_or(false)
 }
 
 fn split_global_args(
@@ -198,60 +387,4 @@ fn split_global_args(
         }
     }
     Ok((mode, base_dir, command_args))
-}
-
-fn parse_export_postgres_args(
-    args: &[String],
-) -> Result<BacktestExportPostgresConfig, Box<dyn std::error::Error>> {
-    let mut mode = BinanceMode::Demo;
-    let mut base_dir = "var".to_string();
-    let mut postgres_url = None;
-    let mut selection = None;
-    let mut index = 0usize;
-    while index < args.len() {
-        match args[index].as_str() {
-            "latest" => {
-                selection = Some(BacktestExportSelection::Latest);
-                index += 1;
-            }
-            "show" => {
-                let raw = args.get(index + 1).ok_or("missing run id for show")?;
-                let run_id = raw
-                    .parse::<i64>()
-                    .map_err(|_| format!("invalid run id: {raw}"))?;
-                selection = Some(BacktestExportSelection::Show(run_id));
-                index += 2;
-            }
-            "--mode" => {
-                let value = args.get(index + 1).ok_or("missing value for --mode")?;
-                mode = match value.as_str() {
-                    "demo" => BinanceMode::Demo,
-                    "real" => BinanceMode::Real,
-                    _ => return Err(format!("unsupported mode: {value}").into()),
-                };
-                index += 2;
-            }
-            "--base-dir" => {
-                let value = args.get(index + 1).ok_or("missing value for --base-dir")?;
-                base_dir = value.clone();
-                index += 2;
-            }
-            "--postgres-url" => {
-                let value = args
-                    .get(index + 1)
-                    .ok_or("missing value for --postgres-url")?;
-                postgres_url = Some(value.clone());
-                index += 2;
-            }
-            other => return Err(format!("unsupported arg: {other}").into()),
-        }
-    }
-    let selection =
-        selection.ok_or("usage: sandbox-quant-backtest export postgres latest|show <run_id>")?;
-    Ok(BacktestExportPostgresConfig {
-        mode,
-        base_dir,
-        postgres_url,
-        selection,
-    })
 }

--- a/src/bin/sandbox-quant-collector.rs
+++ b/src/bin/sandbox-quant-collector.rs
@@ -1,4 +1,4 @@
-use chrono::NaiveDate;
+use chrono::{NaiveDate, Utc};
 use duckdb::Connection;
 use sandbox_quant::app::bootstrap::BinanceMode;
 use sandbox_quant::collector_app::binance_public::{
@@ -7,12 +7,14 @@ use sandbox_quant::collector_app::binance_public::{
 };
 use sandbox_quant::dataset::schema::{init_schema_for_path, MARKET_DATA_SCHEMA_VERSION};
 use sandbox_quant::error::storage_error::StorageError;
+use sandbox_quant::observability::logging::init_logging;
 use sandbox_quant::record::coordination::RecorderCoordination;
 use sandbox_quant::storage::postgres_market_data::{
     connect as connect_postgres, export_snapshot_to_duckdb, init_schema as init_postgres_schema,
     load_summary as load_postgres_summary, postgres_url_from_env, CollectorStorageBackend,
     PostgresToDuckDbSnapshotConfig,
 };
+use tracing::{error, info};
 
 #[derive(Debug, Clone, PartialEq)]
 struct BatchImportConfig {
@@ -48,13 +50,31 @@ struct SnapshotConfig {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = std::env::args().skip(1).collect();
-    match args.first().map(String::as_str) {
+    let init_mode = args
+        .windows(2)
+        .find(|window| window[0] == "--mode")
+        .map(|window| window[1].as_str())
+        .unwrap_or("demo");
+    init_logging("collector", Some(init_mode))?;
+    info!(service = "collector", mode = init_mode, args = ?args, "process started");
+
+    let result: Result<(), Box<dyn std::error::Error>> = match args.first().map(String::as_str) {
         Some("binance-public") if args.get(1).map(String::as_str) == Some("import") => {
             let config = parse_import_args(&args[2..])?;
             let report = import_many(&config)?;
+            info!(
+                service = "collector",
+                mode = config.mode.as_str(),
+                storage = config.storage_backend.as_str(),
+                symbols = %config.symbols.join(","),
+                liquidation_rows = report.liquidation_rows,
+                kline_rows = report.kline_rows,
+                "collector import completed"
+            );
             println!(
                 "{}",
-                [
+                {
+                    let mut lines = vec![
                     "collector import".to_string(),
                     format!("storage={}", config.storage_backend.as_str()),
                     format!("products={}", join_products(&config.products)),
@@ -72,9 +92,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     format!("skipped_kline_dates={}", report.skipped_kline_dates),
                     format!("liquidation_rows={}", report.liquidation_rows),
                     format!("kline_rows={}", report.kline_rows),
-                ]
-                .join("\n")
+                    ];
+                    if let Some(warning) = archive_gap_warning(&config, &report) {
+                        lines.push(warning);
+                    }
+                    lines.join("\n")
+                }
             );
+            Ok(())
         }
         Some("summary") => {
             let (mode, base_dir, storage_backend, postgres_url) = parse_summary_args(&args[1..])?;
@@ -82,6 +107,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "{}",
                 render_summary(mode, &base_dir, storage_backend, postgres_url.as_deref())?
             );
+            info!(service = "collector", mode = mode.as_str(), storage = storage_backend.as_str(), "collector summary completed");
+            Ok(())
         }
         Some("snapshot") if args.get(1).map(String::as_str) == Some("postgres-to-duckdb") => {
             let config = parse_snapshot_args(&args[2..])?;
@@ -128,14 +155,29 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 ]
                 .join("\n")
             );
-        }
-        _ => {
-            eprintln!(
-                "usage: sandbox-quant-collector binance-public import (--product <spot|um|cm> | --products <spot,um,cm>) (--symbol <symbol> | --symbols <a,b,c>) (--date <YYYY-MM-DD> | --from <YYYY-MM-DD> --to <YYYY-MM-DD>) [--kline-interval <interval>] [--mode <demo|real>] [--base-dir <path>] [--skip-liquidation] [--skip-klines] [--storage <duckdb|postgres>] [--postgres-url <url>]\n       sandbox-quant-collector summary [--mode <demo|real>] [--base-dir <path>] [--storage <duckdb|postgres>] [--postgres-url <url>]\n       sandbox-quant-collector snapshot postgres-to-duckdb (--symbol <symbol> | --symbols <a,b,c>) (--date <YYYY-MM-DD> | --from <YYYY-MM-DD> --to <YYYY-MM-DD>) [--mode <demo|real>] [--base-dir <path>] [--product <spot|um|cm>] [--interval <interval>] [--postgres-url <url>] [--skip-klines] [--skip-liquidations] [--skip-book-tickers] [--skip-agg-trades] [--no-clear]"
+            info!(
+                service = "collector",
+                mode = config.mode.as_str(),
+                symbols = %config.symbols.join(","),
+                kline_rows = report.kline_rows,
+                liquidation_rows = report.liquidation_rows,
+                book_ticker_rows = report.book_ticker_rows,
+                agg_trade_rows = report.agg_trade_rows,
+                "collector snapshot completed"
             );
-            std::process::exit(2);
+            Ok(())
         }
+        _ => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "usage: sandbox-quant-collector binance-public import (--product <spot|um|cm> | --products <spot,um,cm>) (--symbol <symbol> | --symbols <a,b,c>) (--date <YYYY-MM-DD> | --from <YYYY-MM-DD> --to <YYYY-MM-DD>) [--kline-interval <interval>] [--mode <demo|real>] [--base-dir <path>] [--skip-liquidation] [--skip-klines] [--storage <duckdb|postgres>] [--postgres-url <url>]\n       sandbox-quant-collector summary [--mode <demo|real>] [--base-dir <path>] [--storage <duckdb|postgres>] [--postgres-url <url>]\n       sandbox-quant-collector snapshot postgres-to-duckdb (--symbol <symbol> | --symbols <a,b,c>) (--date <YYYY-MM-DD> | --from <YYYY-MM-DD> --to <YYYY-MM-DD>) [--mode <demo|real>] [--base-dir <path>] [--product <spot|um|cm>] [--interval <interval>] [--postgres-url <url>] [--skip-klines] [--skip-liquidations] [--skip-book-tickers] [--skip-agg-trades] [--no-clear]",
+        )
+        .into()),
+    };
+    if let Err(error) = result {
+        error!(service = "collector", mode = init_mode, error = %error, "process failed");
+        return Err(error);
     }
+    info!(service = "collector", mode = init_mode, "process completed");
     Ok(())
 }
 
@@ -559,6 +601,26 @@ fn import_many(
     }
 
     Ok(total)
+}
+
+fn archive_gap_warning(
+    config: &BatchImportConfig,
+    report: &BinancePublicImportReport,
+) -> Option<String> {
+    if config.storage_backend != CollectorStorageBackend::Postgres {
+        return None;
+    }
+    if report.kline_rows > 0 || report.skipped_kline_dates == 0 {
+        return None;
+    }
+    let today_utc = Utc::now().date_naive();
+    if config.to < today_utc {
+        return None;
+    }
+    Some(format!(
+        "warning=current_day_archive_not_available use=postgres_kline_backfill from={} to={} today_utc={}",
+        config.from, config.to, today_utc
+    ))
 }
 
 fn join_products(products: &[BinancePublicProduct]) -> String {

--- a/src/bin/sandbox-quant-recorder.rs
+++ b/src/bin/sandbox-quant-recorder.rs
@@ -1,64 +1,429 @@
-use std::thread;
-use std::time::Duration;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
 
+use axum::{
+    extract::State,
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use chrono::Utc;
+use reqwest::blocking::Client;
 use sandbox_quant::app::bootstrap::BinanceMode;
 use sandbox_quant::app::cli::normalize_instrument_symbol;
+use sandbox_quant::market_data::binance_kline_backfill::{
+    parse_start_time, run_binance_kline_backfill, BinanceKlineBackfillConfig,
+    DEFAULT_BINANCE_BACKFILL_INTERVAL, DEFAULT_BINANCE_BACKFILL_PRODUCT,
+    DEFAULT_BINANCE_BACKFILL_START_DATE,
+};
+use sandbox_quant::observability::logging::init_logging;
 use sandbox_quant::record::coordination::RecorderCoordination;
-use sandbox_quant::recorder_app::runtime::{MarketDataRecorder, RecorderState};
+use sandbox_quant::recorder_app::runtime::MarketDataRecorder;
 use sandbox_quant::recorder_app::terminal::RecorderTerminal;
+use sandbox_quant::storage::postgres_market_data::{
+    market_freshness_for_postgres_url, postgres_url_from_env, PostgresMarketFreshness,
+};
 use sandbox_quant::terminal::loop_shell::run_terminal;
 use sandbox_quant::ui::recorder_output::render_live_recorder_status;
+use serde::Serialize;
+use serde_json::json;
+use std::path::Path;
+use tracing::{error, info, warn};
+
+const DEFAULT_RECORDER_SERVER_ADDR: &str = "127.0.0.1:9781";
+const RECORDER_RUNTIME_MODE: BinanceMode = BinanceMode::Demo;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    bootstrap_recorder_env();
     let args: Vec<String> = std::env::args().skip(1).collect();
-    if args.is_empty()
+    init_logging("recorder", None)?;
+    info!(service = "recorder", args = ?args, "process started");
+
+    let result: Result<(), Box<dyn std::error::Error>> = if args.is_empty()
         || matches!(
             args.first().map(String::as_str),
             Some("--mode") | Some("--base-dir")
-        )
-    {
+        ) {
         let (mode, base_dir) = parse_terminal_args(&args)?;
         let mut terminal = RecorderTerminal::new(mode, base_dir);
-        return run_terminal(&mut terminal);
-    }
-
-    match args.first().map(String::as_str) {
-        Some("run") => run_recorder(&args[1..])?,
-        _ => {
-            eprintln!(
-                "usage: sandbox-quant-recorder [--mode <demo|real>] [--base-dir <path>]\n       sandbox-quant-recorder run [symbols...] [--mode <demo|real>] [--base-dir <path>]"
-            );
-            std::process::exit(2);
+        run_terminal(&mut terminal)
+    } else {
+        match args.first().map(String::as_str) {
+            Some("run") | Some("serve") => serve_recorder(&args[1..]),
+            Some("status") => {
+                print!("{}", request_recorder_server("GET", "/status", parse_server_addr(&args[1..])?)?);
+                Ok(())
+            }
+            Some("health") => {
+                print!("{}", request_recorder_server("GET", "/health", parse_server_addr(&args[1..])?)?);
+                Ok(())
+            }
+            Some("freshness") => {
+                print!(
+                    "{}",
+                    request_recorder_server("GET", "/freshness", parse_server_addr(&args[1..])?)?
+                );
+                Ok(())
+            }
+            Some("stop") => {
+                print!("{}", request_recorder_server("POST", "/stop", parse_server_addr(&args[1..])?)?);
+                Ok(())
+            }
+            _ => {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "usage: sandbox-quant-recorder [--mode <demo|real>] [--base-dir <path>]\n       sandbox-quant-recorder serve [symbols...] [--base-dir <path>] [--backfill] [--backfill-poll-seconds <n>] [--listen <addr>]\n       sandbox-quant-recorder run [symbols...] [--base-dir <path>] [--backfill] [--backfill-poll-seconds <n>] [--listen <addr>]\n       sandbox-quant-recorder status [--listen <addr>]\n       sandbox-quant-recorder health [--listen <addr>]\n       sandbox-quant-recorder freshness [--listen <addr>]\n       sandbox-quant-recorder stop [--listen <addr>]",
+                )
+                .into())
+            }
         }
+    };
+    if let Err(error) = result {
+        error!(service = "recorder", error = %error, "process failed");
+        return Err(error);
     }
-
+    info!(service = "recorder", "process completed");
     Ok(())
 }
 
-fn run_recorder(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
-    let (mode, base_dir, symbols) = parse_run_args(args)?;
-    let coordination = RecorderCoordination::new(base_dir.clone());
-    let strategy_symbols = coordination.strategy_symbols(mode)?;
-    let mut recorder = MarketDataRecorder::new(base_dir.clone());
-    let status = recorder.start(mode, symbols, strategy_symbols)?;
-    println!("{}", render_live_recorder_status("record running", &status));
-
-    loop {
-        thread::sleep(Duration::from_secs(1));
-        let status = recorder.status(mode);
-        if status.state != RecorderState::Running {
-            break;
-        }
-        if !status.worker_alive {
-            eprintln!(
-                "recorder worker is not alive; restarting streams for mode={}",
-                mode.as_str()
-            );
-            recorder.update_manual_symbols(mode, status.manual_symbols.clone())?;
+fn bootstrap_recorder_env() {
+    if std::env::var_os("SANDBOX_QUANT_DISABLE_DOTENV").is_none() {
+        dotenvy::dotenv().ok();
+        for path in [
+            Path::new("ops/grafana/.env").to_path_buf(),
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("ops/grafana/.env"),
+        ] {
+            if path.exists() {
+                let _ = dotenvy::from_path(&path);
+            }
         }
     }
 
-    Ok(())
+    if std::env::var_os("SANDBOX_QUANT_POSTGRES_URL").is_none()
+        && std::env::var_os("DATABASE_URL").is_none()
+    {
+        if let Ok(url) = postgres_url_from_env() {
+            std::env::set_var("SANDBOX_QUANT_POSTGRES_URL", url);
+        }
+    }
+
+    if std::env::var_os("SANDBOX_QUANT_RECORDER_STORAGE").is_none()
+        && std::env::var_os("SANDBOX_QUANT_POSTGRES_URL").is_some()
+    {
+        std::env::set_var("SANDBOX_QUANT_RECORDER_STORAGE", "postgres");
+    }
+}
+
+#[derive(Debug)]
+struct RecorderDaemon {
+    recorder: MarketDataRecorder,
+    backfill_worker: Option<BackfillWorker>,
+    last_heartbeat_log: Instant,
+}
+
+#[derive(Debug)]
+struct BackfillWorker {
+    stop_flag: Arc<AtomicBool>,
+    handle: JoinHandle<()>,
+}
+
+#[derive(Clone)]
+struct RecorderServerState {
+    daemon: Arc<Mutex<RecorderDaemon>>,
+    shutdown: Arc<AtomicBool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RecorderRunConfig {
+    base_dir: String,
+    symbols: Vec<String>,
+    backfill: bool,
+    backfill_poll_seconds: u64,
+    listen_addr: String,
+}
+
+#[derive(Debug, Serialize)]
+struct RecorderHealthResponse {
+    state: String,
+    reader_alive: bool,
+    writer_alive: bool,
+    worker_alive: bool,
+    heartbeat_age_sec: i64,
+    storage_backend: String,
+    watched_symbols: Vec<String>,
+    last_error: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct RecorderFreshnessResponse {
+    state: String,
+    storage_backend: String,
+    reader_alive: bool,
+    writer_alive: bool,
+    worker_alive: bool,
+    backfill_enabled: bool,
+    backfill_alive: bool,
+    watched_symbols: Vec<String>,
+    postgres: Option<PostgresMarketFreshness>,
+}
+
+fn serve_recorder(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    let config = parse_run_args(args)?;
+    let base_dir = config.base_dir.clone();
+    let symbols = config.symbols.clone();
+    let coordination = RecorderCoordination::new(base_dir.clone());
+    let strategy_symbols = coordination.strategy_symbols(RECORDER_RUNTIME_MODE)?;
+    let mut recorder = MarketDataRecorder::new(base_dir.clone());
+    let status = recorder.start(RECORDER_RUNTIME_MODE, symbols, strategy_symbols)?;
+    println!("{}", render_live_recorder_status("record running", &status));
+    let backfill_worker = if config.backfill {
+        Some(spawn_backfill_worker(&config)?)
+    } else {
+        None
+    };
+    let daemon = Arc::new(Mutex::new(RecorderDaemon {
+        recorder,
+        backfill_worker,
+        last_heartbeat_log: Instant::now()
+            .checked_sub(Duration::from_secs(5))
+            .unwrap_or_else(Instant::now),
+    }));
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let state = RecorderServerState {
+        daemon: daemon.clone(),
+        shutdown: shutdown.clone(),
+    };
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+
+    runtime.block_on(async move {
+        let app = Router::new()
+            .route("/status", get(recorder_status_handler))
+            .route("/health", get(recorder_health_handler))
+            .route("/freshness", get(recorder_freshness_handler))
+            .route("/stop", post(recorder_stop_handler))
+            .with_state(state.clone());
+
+        let listener = tokio::net::TcpListener::bind(&config.listen_addr).await?;
+        info!(
+            service = "recorder",
+            listen_addr = %config.listen_addr,
+            "recorder control server listening"
+        );
+
+        let supervisor_state = state.clone();
+        let supervisor = tokio::spawn(async move {
+            loop {
+                if supervisor_state.shutdown.load(Ordering::Relaxed) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                let mut daemon = match supervisor_state.daemon.lock() {
+                    Ok(daemon) => daemon,
+                    Err(_) => continue,
+                };
+                let status = daemon.recorder.status(RECORDER_RUNTIME_MODE);
+                if daemon.last_heartbeat_log.elapsed() >= Duration::from_secs(5) {
+                    info!(
+                        service = "recorder",
+                        kind = "heartbeat",
+                        ping_at = %Utc::now().to_rfc3339(),
+                        pong_at = %status.updated_at.to_rfc3339(),
+                        heartbeat_age_sec = status.heartbeat_age_sec,
+                        reader_alive = status.reader_alive,
+                        writer_alive = status.writer_alive,
+                        worker_alive = status.worker_alive,
+                        storage_backend = status.storage_backend,
+                        watched_symbols = %status.watched_symbols.join(","),
+                        "heartbeat ping/pong"
+                    );
+                    daemon.last_heartbeat_log = Instant::now();
+                }
+                if !status.worker_alive {
+                    let manual_symbols = status.manual_symbols.clone();
+                    warn!(
+                        service = "recorder",
+                        "worker not alive; restarting streams"
+                    );
+                    let _ = daemon
+                        .recorder
+                        .update_manual_symbols(RECORDER_RUNTIME_MODE, manual_symbols);
+                }
+            }
+        });
+
+        let shutdown_signal = async move {
+            while !shutdown.load(Ordering::Relaxed) {
+                tokio::time::sleep(Duration::from_millis(250)).await;
+            }
+        };
+
+        let result = axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown_signal)
+            .await;
+        let _ = supervisor.await;
+
+        let mut daemon = daemon
+            .lock()
+            .map_err(|_| "failed to lock recorder daemon state")?;
+        let _ = daemon.recorder.stop(RECORDER_RUNTIME_MODE);
+        if let Some(worker) = daemon.backfill_worker.take() {
+            worker.stop_flag.store(true, Ordering::Relaxed);
+            let _ = worker.handle.join();
+        }
+        info!(service = "recorder", "serve loop completed");
+        result.map_err(|error| -> Box<dyn std::error::Error> { Box::new(error) })
+    })
+}
+
+fn spawn_backfill_worker(
+    config: &RecorderRunConfig,
+) -> Result<BackfillWorker, Box<dyn std::error::Error>> {
+    let stop_flag = Arc::new(AtomicBool::new(false));
+    let worker_stop_flag = stop_flag.clone();
+    let backfill_config = BinanceKlineBackfillConfig {
+        postgres_url: std::env::var("SANDBOX_QUANT_POSTGRES_URL")?,
+        symbols: config.symbols.clone(),
+        mode: RECORDER_RUNTIME_MODE,
+        product: DEFAULT_BINANCE_BACKFILL_PRODUCT.to_string(),
+        interval: DEFAULT_BINANCE_BACKFILL_INTERVAL.to_string(),
+        fallback_start_ms: parse_start_time(DEFAULT_BINANCE_BACKFILL_START_DATE)?,
+        continuous: true,
+        poll_seconds: config.backfill_poll_seconds,
+    };
+    let handle = std::thread::Builder::new()
+        .name("market-recorder-kline-backfill".to_string())
+        .spawn(move || {
+            if let Err(error) = run_binance_kline_backfill(&backfill_config, Some(worker_stop_flag))
+            {
+                error!(
+                    service = "recorder",
+                    backfill = "binance-kline",
+                    error = %error,
+                    "in-process kline backfill stopped with error"
+                );
+            }
+        })?;
+    info!(
+        service = "recorder",
+        backfill_symbols = %config.symbols.join(","),
+        backfill_poll_seconds = config.backfill_poll_seconds,
+        "spawned in-process kline backfill worker"
+    );
+    Ok(BackfillWorker { stop_flag, handle })
+}
+
+async fn recorder_status_handler(
+    State(state): State<RecorderServerState>,
+) -> Result<String, axum::http::StatusCode> {
+    let daemon = state
+        .daemon
+        .lock()
+        .map_err(|_| axum::http::StatusCode::INTERNAL_SERVER_ERROR)?;
+    let status = daemon.recorder.status(RECORDER_RUNTIME_MODE);
+    Ok(render_live_recorder_status("record status", &status))
+}
+
+async fn recorder_health_handler(
+    State(state): State<RecorderServerState>,
+) -> Result<Json<RecorderHealthResponse>, axum::http::StatusCode> {
+    let daemon = state
+        .daemon
+        .lock()
+        .map_err(|_| axum::http::StatusCode::INTERNAL_SERVER_ERROR)?;
+    let status = daemon.recorder.status(RECORDER_RUNTIME_MODE);
+    Ok(Json(RecorderHealthResponse {
+        state: status.state.as_str().to_string(),
+        reader_alive: status.reader_alive,
+        writer_alive: status.writer_alive,
+        worker_alive: status.worker_alive,
+        heartbeat_age_sec: status.heartbeat_age_sec,
+        storage_backend: status.storage_backend,
+        watched_symbols: status.watched_symbols,
+        last_error: status.last_error,
+    }))
+}
+
+async fn recorder_freshness_handler(
+    State(state): State<RecorderServerState>,
+) -> Result<Json<RecorderFreshnessResponse>, axum::http::StatusCode> {
+    tokio::task::spawn_blocking(move || {
+        let daemon = state
+            .daemon
+            .lock()
+            .map_err(|_| axum::http::StatusCode::INTERNAL_SERVER_ERROR)?;
+        let status = daemon.recorder.status(RECORDER_RUNTIME_MODE);
+        let backfill_enabled = daemon.backfill_worker.is_some();
+        let backfill_alive = daemon
+            .backfill_worker
+            .as_ref()
+            .is_some_and(|worker| !worker.handle.is_finished());
+        let postgres = if status.storage_backend == "postgres" {
+            std::env::var("SANDBOX_QUANT_POSTGRES_URL")
+                .ok()
+                .and_then(|url| market_freshness_for_postgres_url(&url, "1m").ok())
+        } else {
+            None
+        };
+        Ok(Json(RecorderFreshnessResponse {
+            state: status.state.as_str().to_string(),
+            storage_backend: status.storage_backend,
+            reader_alive: status.reader_alive,
+            writer_alive: status.writer_alive,
+            worker_alive: status.worker_alive,
+            backfill_enabled,
+            backfill_alive,
+            watched_symbols: status.watched_symbols,
+            postgres,
+        }))
+    })
+    .await
+    .map_err(|_| axum::http::StatusCode::INTERNAL_SERVER_ERROR)?
+}
+
+async fn recorder_stop_handler(State(state): State<RecorderServerState>) -> impl IntoResponse {
+    state.shutdown.store(true, Ordering::Relaxed);
+    Json(json!({ "status": "stopping" }))
+}
+
+fn request_recorder_server(
+    method: &str,
+    path: &str,
+    listen_addr: String,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let client = Client::builder().build()?;
+    let url = format!("http://{listen_addr}{path}");
+    let response = match method {
+        "GET" => client.get(url).send()?,
+        "POST" => client.post(url).send()?,
+        other => return Err(format!("unsupported method: {other}").into()),
+    }
+    .error_for_status()?;
+    Ok(response.text()?)
+}
+
+fn parse_server_addr(args: &[String]) -> Result<String, Box<dyn std::error::Error>> {
+    let mut listen_addr = DEFAULT_RECORDER_SERVER_ADDR.to_string();
+    let mut index = 0usize;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--listen" => {
+                listen_addr = args
+                    .get(index + 1)
+                    .ok_or("missing value for --listen")?
+                    .clone();
+                index += 2;
+            }
+            other => return Err(format!("unsupported arg: {other}").into()),
+        }
+    }
+    Ok(listen_addr)
 }
 
 fn parse_terminal_args(
@@ -89,28 +454,40 @@ fn parse_terminal_args(
     Ok((mode, base_dir))
 }
 
-fn parse_run_args(
-    args: &[String],
-) -> Result<(BinanceMode, String, Vec<String>), Box<dyn std::error::Error>> {
-    let mut mode = BinanceMode::Demo;
+fn parse_run_args(args: &[String]) -> Result<RecorderRunConfig, Box<dyn std::error::Error>> {
     let mut base_dir = "var".to_string();
     let mut symbols = Vec::new();
+    let mut backfill = false;
+    let mut backfill_poll_seconds = 30u64;
+    let mut listen_addr = DEFAULT_RECORDER_SERVER_ADDR.to_string();
     let mut index = 0usize;
     while index < args.len() {
         match args[index].as_str() {
-            "--mode" => {
-                let value = args.get(index + 1).ok_or("missing value for --mode")?;
-                mode = match value.as_str() {
-                    "demo" => BinanceMode::Demo,
-                    "real" => BinanceMode::Real,
-                    _ => return Err(format!("unsupported mode: {value}").into()),
-                };
-                index += 2;
-            }
             "--base-dir" => {
                 let value = args.get(index + 1).ok_or("missing value for --base-dir")?;
                 base_dir = value.clone();
                 index += 2;
+            }
+            "--backfill" => {
+                backfill = true;
+                index += 1;
+            }
+            "--backfill-poll-seconds" => {
+                let value = args
+                    .get(index + 1)
+                    .ok_or("missing value for --backfill-poll-seconds")?;
+                backfill_poll_seconds = value.parse::<u64>()?;
+                index += 2;
+            }
+            "--listen" => {
+                listen_addr = args
+                    .get(index + 1)
+                    .ok_or("missing value for --listen")?
+                    .clone();
+                index += 2;
+            }
+            raw if raw.starts_with("--") => {
+                return Err(format!("unsupported arg: {raw}").into());
             }
             raw => {
                 symbols.push(normalize_instrument_symbol(raw));
@@ -118,5 +495,11 @@ fn parse_run_args(
             }
         }
     }
-    Ok((mode, base_dir, symbols))
+    Ok(RecorderRunConfig {
+        base_dir,
+        symbols,
+        backfill,
+        backfill_poll_seconds,
+        listen_addr,
+    })
 }

--- a/src/bin/sandbox-quant-watchdog.rs
+++ b/src/bin/sandbox-quant-watchdog.rs
@@ -1,0 +1,810 @@
+use std::collections::VecDeque;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use chrono::{DateTime, FixedOffset, Utc};
+use postgres::Client;
+use sandbox_quant::dataset::types::RecorderMetrics;
+use sandbox_quant::error::storage_error::StorageError;
+use sandbox_quant::storage::postgres_market_data::{connect, init_schema, postgres_url_from_env};
+use serde::Serialize;
+use serde_json::Value;
+
+const EXIT_HEALTHY: u8 = 0;
+const EXIT_STALE: u8 = 20;
+const EXIT_ERROR: u8 = 30;
+
+fn main() -> ExitCode {
+    dotenvy::dotenv().ok();
+
+    match run() {
+        Ok(code) => ExitCode::from(code),
+        Err(error) => {
+            eprintln!("{error}");
+            ExitCode::from(EXIT_ERROR)
+        }
+    }
+}
+
+fn run() -> Result<u8, Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match args.first().map(String::as_str) {
+        Some("probe") => run_probe(&args[1..]),
+        _ => Err(
+            "usage: sandbox-quant-watchdog probe [--heartbeat-log <path>] [--postgres-url <url>] [--market-max-age-sec <sec>] [--heartbeat-max-age-sec <sec>] [--liquidation-max-age-sec <sec>]"
+                .into(),
+        ),
+    }
+}
+
+fn run_probe(args: &[String]) -> Result<u8, Box<dyn std::error::Error>> {
+    let config = ProbeConfig::parse(args)?;
+    let checked_at = Utc::now();
+    let heartbeat = read_log_snapshot(&config.heartbeat_log)?;
+    let metrics = load_metrics(&config.postgres_url);
+
+    let report = build_probe_report(config, checked_at, metrics, heartbeat);
+    println!("{}", serde_json::to_string_pretty(&report)?);
+
+    Ok(match report.status.as_str() {
+        "healthy" => EXIT_HEALTHY,
+        "stale" => EXIT_STALE,
+        _ => EXIT_ERROR,
+    })
+}
+
+#[derive(Debug, Clone)]
+struct ProbeConfig {
+    heartbeat_log: PathBuf,
+    postgres_url: String,
+    market_max_age_sec: i64,
+    heartbeat_max_age_sec: i64,
+    liquidation_max_age_sec: Option<i64>,
+}
+
+impl ProbeConfig {
+    fn parse(args: &[String]) -> Result<Self, Box<dyn std::error::Error>> {
+        let mut heartbeat_log: Option<PathBuf> = None;
+        let mut postgres_url: Option<String> = None;
+        let mut market_max_age_sec = 240i64;
+        let mut heartbeat_max_age_sec = 240i64;
+        let mut liquidation_max_age_sec = None;
+
+        let mut index = 0usize;
+        while index < args.len() {
+            match args[index].as_str() {
+                "--heartbeat-log" => {
+                    let value = args
+                        .get(index + 1)
+                        .ok_or("missing value for --heartbeat-log")?;
+                    heartbeat_log = Some(PathBuf::from(value));
+                    index += 2;
+                }
+                "--postgres-url" => {
+                    let value = args
+                        .get(index + 1)
+                        .ok_or("missing value for --postgres-url")?;
+                    postgres_url = Some(value.clone());
+                    index += 2;
+                }
+                "--market-max-age-sec" => {
+                    let value = args
+                        .get(index + 1)
+                        .ok_or("missing value for --market-max-age-sec")?;
+                    market_max_age_sec = value.parse()?;
+                    index += 2;
+                }
+                "--heartbeat-max-age-sec" => {
+                    let value = args
+                        .get(index + 1)
+                        .ok_or("missing value for --heartbeat-max-age-sec")?;
+                    heartbeat_max_age_sec = value.parse()?;
+                    index += 2;
+                }
+                "--liquidation-max-age-sec" => {
+                    let value = args
+                        .get(index + 1)
+                        .ok_or("missing value for --liquidation-max-age-sec")?;
+                    let parsed: i64 = value.parse()?;
+                    liquidation_max_age_sec = if parsed <= 0 { None } else { Some(parsed) };
+                    index += 2;
+                }
+                other => return Err(format!("unsupported arg: {other}").into()),
+            }
+        }
+
+        let heartbeat_log =
+            heartbeat_log.unwrap_or_else(|| PathBuf::from("var/log/recorder.jsonl"));
+        let postgres_url =
+            postgres_url.unwrap_or_else(|| postgres_url_from_env().unwrap_or_default());
+        if postgres_url.trim().is_empty() {
+            return Err(
+                "postgres URL missing; set SANDBOX_QUANT_POSTGRES_URL or pass --postgres-url"
+                    .into(),
+            );
+        }
+
+        Ok(Self {
+            heartbeat_log,
+            postgres_url,
+            market_max_age_sec,
+            heartbeat_max_age_sec,
+            liquidation_max_age_sec,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ProbeThresholds {
+    market_max_age_sec: i64,
+    heartbeat_max_age_sec: i64,
+    liquidation_max_age_sec: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ProbeReport {
+    status: String,
+    checked_at: String,
+    heartbeat_log: String,
+    thresholds: ProbeThresholds,
+    metrics: Option<MetricSnapshot>,
+    heartbeat: Option<HeartbeatSnapshot>,
+    staleness: StalenessReport,
+    diagnosis: Diagnosis,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct MetricSnapshot {
+    liquidation_events: u64,
+    book_ticker_events: u64,
+    agg_trade_events: u64,
+    last_liquidation_event_time: Option<String>,
+    last_book_ticker_event_time: Option<String>,
+    last_agg_trade_event_time: Option<String>,
+    top_liquidation_symbols: Vec<String>,
+    top_book_ticker_symbols: Vec<String>,
+    top_agg_trade_symbols: Vec<String>,
+    ages_sec: MetricAges,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct MetricAges {
+    liquidation: Option<i64>,
+    book_ticker: Option<i64>,
+    agg_trade: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct HeartbeatSnapshot {
+    ping_at: String,
+    pong_at: String,
+    reader_alive: bool,
+    writer_alive: bool,
+    worker_alive: bool,
+    watched_symbols: Vec<String>,
+    heartbeat_age_sec: Option<i64>,
+}
+
+#[derive(Debug, Clone)]
+struct LogSnapshot {
+    last_heartbeat: Option<HeartbeatSnapshot>,
+    recent_errors: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct StalenessReport {
+    market_data_stale: bool,
+    heartbeat_stale: bool,
+    liquidation_stale: bool,
+    reasons: Vec<String>,
+    recent_errors: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct Diagnosis {
+    category: String,
+    summary: String,
+}
+
+fn build_probe_report(
+    config: ProbeConfig,
+    checked_at: DateTime<Utc>,
+    metrics: Result<RecorderMetrics, StorageError>,
+    heartbeat: LogSnapshot,
+) -> ProbeReport {
+    let checked_at_text = checked_at.to_rfc3339();
+    let thresholds = ProbeThresholds {
+        market_max_age_sec: config.market_max_age_sec,
+        heartbeat_max_age_sec: config.heartbeat_max_age_sec,
+        liquidation_max_age_sec: config.liquidation_max_age_sec,
+    };
+    match metrics {
+        Ok(metrics) => {
+            let ages = MetricAges {
+                liquidation: age_from_text(
+                    metrics.last_liquidation_event_time.as_deref(),
+                    checked_at,
+                ),
+                book_ticker: age_from_text(
+                    metrics.last_book_ticker_event_time.as_deref(),
+                    checked_at,
+                ),
+                agg_trade: age_from_text(metrics.last_agg_trade_event_time.as_deref(), checked_at),
+            };
+            let metric_snapshot = MetricSnapshot {
+                liquidation_events: metrics.liquidation_events,
+                book_ticker_events: metrics.book_ticker_events,
+                agg_trade_events: metrics.agg_trade_events,
+                last_liquidation_event_time: metrics.last_liquidation_event_time.clone(),
+                last_book_ticker_event_time: metrics.last_book_ticker_event_time.clone(),
+                last_agg_trade_event_time: metrics.last_agg_trade_event_time.clone(),
+                top_liquidation_symbols: metrics.top_liquidation_symbols,
+                top_book_ticker_symbols: metrics.top_book_ticker_symbols,
+                top_agg_trade_symbols: metrics.top_agg_trade_symbols,
+                ages_sec: ages.clone(),
+            };
+            let market_age = youngest_age(ages.book_ticker, ages.agg_trade);
+            let market_data_stale = market_age.is_none_or(|age| age > config.market_max_age_sec);
+            let heartbeat_age = heartbeat
+                .last_heartbeat
+                .as_ref()
+                .and_then(|snapshot| snapshot.heartbeat_age_sec);
+            let heartbeat_stale = heartbeat
+                .last_heartbeat
+                .as_ref()
+                .map(|snapshot| {
+                    !snapshot.worker_alive || !snapshot.reader_alive || !snapshot.writer_alive
+                })
+                .unwrap_or(true)
+                || heartbeat_age.is_none_or(|age| age > config.heartbeat_max_age_sec);
+            let liquidation_stale = match config.liquidation_max_age_sec {
+                Some(limit) => ages.liquidation.is_none_or(|age| age > limit),
+                None => false,
+            };
+
+            let mut reasons = Vec::new();
+            if market_data_stale {
+                reasons.push(format!(
+                    "market_data_age_exceeded max={} observed={}",
+                    config.market_max_age_sec,
+                    market_age
+                        .map(|age| age.to_string())
+                        .unwrap_or_else(|| "missing".to_string())
+                ));
+            }
+            if heartbeat_stale {
+                reasons.push(format!(
+                    "heartbeat_age_exceeded max={} observed={} worker_alive={} reader_alive={} writer_alive={}",
+                    config.heartbeat_max_age_sec,
+                    heartbeat_age
+                        .map(|age| age.to_string())
+                        .unwrap_or_else(|| "missing".to_string()),
+                    heartbeat
+                        .last_heartbeat
+                        .as_ref()
+                        .map(|snapshot| snapshot.worker_alive)
+                        .unwrap_or(false),
+                    heartbeat
+                        .last_heartbeat
+                        .as_ref()
+                        .map(|snapshot| snapshot.reader_alive)
+                        .unwrap_or(false),
+                    heartbeat
+                        .last_heartbeat
+                        .as_ref()
+                        .map(|snapshot| snapshot.writer_alive)
+                        .unwrap_or(false)
+                ));
+                if let Some(snapshot) = heartbeat.last_heartbeat.as_ref() {
+                    reasons.push(format!(
+                        "heartbeat_components reader_alive={} writer_alive={}",
+                        snapshot.reader_alive, snapshot.writer_alive
+                    ));
+                }
+            }
+            if liquidation_stale {
+                reasons.push(format!(
+                    "liquidation_age_exceeded max={} observed={}",
+                    config.liquidation_max_age_sec.unwrap_or_default(),
+                    ages.liquidation
+                        .map(|age| age.to_string())
+                        .unwrap_or_else(|| "missing".to_string())
+                ));
+            }
+
+            let staleness = StalenessReport {
+                market_data_stale,
+                heartbeat_stale,
+                liquidation_stale,
+                reasons,
+                recent_errors: heartbeat.recent_errors.clone(),
+            };
+            let diagnosis = infer_diagnosis(None, &staleness);
+            let status = if staleness.market_data_stale
+                || staleness.heartbeat_stale
+                || staleness.liquidation_stale
+            {
+                "stale".to_string()
+            } else {
+                "healthy".to_string()
+            };
+
+            ProbeReport {
+                status,
+                checked_at: checked_at_text,
+                heartbeat_log: config.heartbeat_log.display().to_string(),
+                thresholds,
+                metrics: Some(metric_snapshot),
+                heartbeat: heartbeat.last_heartbeat,
+                staleness,
+                diagnosis,
+            }
+        }
+        Err(error) => {
+            let storage_error = error.to_string();
+            let staleness = StalenessReport {
+                market_data_stale: true,
+                heartbeat_stale: heartbeat.last_heartbeat.is_none(),
+                liquidation_stale: false,
+                reasons: vec![format!("postgres_probe_failed error={storage_error}")],
+                recent_errors: heartbeat.recent_errors.clone(),
+            };
+            let diagnosis = infer_diagnosis(Some(&storage_error), &staleness);
+            ProbeReport {
+                status: "error".to_string(),
+                checked_at: checked_at_text,
+                heartbeat_log: config.heartbeat_log.display().to_string(),
+                thresholds,
+                metrics: None,
+                heartbeat: heartbeat.last_heartbeat,
+                staleness,
+                diagnosis,
+            }
+        }
+    }
+}
+
+fn load_metrics(url: &str) -> Result<RecorderMetrics, StorageError> {
+    let mut client = connect(url)?;
+    let _ = init_schema(&mut client, url)?;
+    Ok(RecorderMetrics {
+        liquidation_events: query_count_for_table(&mut client, "raw_liquidation_events")?,
+        book_ticker_events: query_count_for_table(&mut client, "raw_book_ticker")?,
+        agg_trade_events: query_count_for_table(&mut client, "raw_agg_trades")?,
+        derived_kline_1s_bars: 0,
+        schema_version: query_schema_version(&mut client)?,
+        last_liquidation_event_time: query_latest_timestamp_for_table(
+            &mut client,
+            "raw_liquidation_events",
+            "event_time",
+        )?,
+        last_book_ticker_event_time: query_latest_timestamp_for_table(
+            &mut client,
+            "raw_book_ticker",
+            "event_time",
+        )?,
+        last_agg_trade_event_time: query_latest_timestamp_for_table(
+            &mut client,
+            "raw_agg_trades",
+            "event_time",
+        )?,
+        top_liquidation_symbols: query_top_symbols_for_table(
+            &mut client,
+            "raw_liquidation_events",
+        )?,
+        top_book_ticker_symbols: query_top_symbols_for_table(&mut client, "raw_book_ticker")?,
+        top_agg_trade_symbols: query_top_symbols_for_table(&mut client, "raw_agg_trades")?,
+    })
+}
+
+fn query_schema_version(client: &mut Client) -> Result<Option<String>, StorageError> {
+    client
+        .query_opt(
+            "SELECT value FROM schema_metadata WHERE key = 'market_data_schema_version'",
+            &[],
+        )
+        .map_err(storage_err)
+        .map(|row| row.map(|row| row.get(0)))
+}
+
+fn query_count_for_table(client: &mut Client, table: &str) -> Result<u64, StorageError> {
+    client
+        .query_one(&format!("SELECT COUNT(*) FROM {table}"), &[])
+        .map_err(storage_err)
+        .map(|row| row.get::<_, i64>(0).max(0) as u64)
+}
+
+fn query_latest_timestamp_for_table(
+    client: &mut Client,
+    table: &str,
+    column: &str,
+) -> Result<Option<String>, StorageError> {
+    client
+        .query_one(
+            &format!("SELECT CAST(MAX({column}) AS TEXT) FROM {table}"),
+            &[],
+        )
+        .map_err(storage_err)
+        .map(|row| row.get(0))
+}
+
+fn query_top_symbols_for_table(
+    client: &mut Client,
+    table: &str,
+) -> Result<Vec<String>, StorageError> {
+    client
+        .query(
+            &format!(
+                "SELECT symbol, COUNT(*) AS row_count
+                 FROM {table}
+                 GROUP BY symbol
+                 ORDER BY row_count DESC, symbol ASC
+                 LIMIT 5"
+            ),
+            &[],
+        )
+        .map_err(storage_err)
+        .map(|rows| {
+            rows.into_iter()
+                .map(|row| format!("{}:{}", row.get::<_, String>(0), row.get::<_, i64>(1)))
+                .collect()
+        })
+}
+
+fn storage_err(error: postgres::Error) -> StorageError {
+    StorageError::WriteFailedWithContext {
+        message: error.to_string(),
+    }
+}
+
+fn youngest_age(left: Option<i64>, right: Option<i64>) -> Option<i64> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left.min(right)),
+        (Some(left), None) => Some(left),
+        (None, Some(right)) => Some(right),
+        (None, None) => None,
+    }
+}
+
+fn infer_diagnosis(storage_error: Option<&str>, staleness: &StalenessReport) -> Diagnosis {
+    let recent_error = staleness.recent_errors.first().map(String::as_str);
+    let category = if let Some(error) = storage_error {
+        if contains_any(error, &["missing", "postgres URL"]) {
+            "postgres_config"
+        } else if contains_any(
+            error,
+            &[
+                "Connection refused",
+                "connection refused",
+                "error connecting to server",
+                "failed to lookup address information",
+                "timeout",
+            ],
+        ) {
+            "postgres_unreachable"
+        } else {
+            "postgres_probe_failed"
+        }
+    } else if !staleness.market_data_stale
+        && !staleness.heartbeat_stale
+        && !staleness.liquidation_stale
+    {
+        "healthy"
+    } else if let Some(error) = recent_error {
+        if contains_any(error, &["failed to lookup address information"]) {
+            "dns_failure"
+        } else if contains_any(error, &["failed to connect forceOrder stream"]) {
+            "liquidation_stream_connect"
+        } else if contains_any(error, &["failed to connect symbol streams"]) {
+            "market_stream_connect"
+        } else if contains_any(
+            error,
+            &[
+                "postgres liquidation writer disconnected",
+                "postgres book_ticker writer disconnected",
+                "postgres agg_trade writer disconnected",
+                "postgres recorder backend missing URL",
+            ],
+        ) {
+            "postgres_writer"
+        } else if contains_any(error, &["process failed", "process panicked"]) {
+            "process_exit"
+        } else {
+            "runtime_error"
+        }
+    } else if staleness.heartbeat_stale && staleness.market_data_stale {
+        "recorder_down"
+    } else if staleness.market_data_stale {
+        "market_data_stale"
+    } else if staleness.liquidation_stale {
+        "liquidation_stale"
+    } else {
+        "healthy"
+    };
+
+    let summary = match category {
+        "healthy" => "market data and recorder heartbeat are fresh".to_string(),
+        "postgres_config" => "postgres URL is missing or invalid; reload env before restarting".to_string(),
+        "postgres_unreachable" => {
+            "postgres probe failed because the database is unreachable; recover postgres first".to_string()
+        }
+        "dns_failure" => "recorder could not resolve an exchange endpoint; check network and restart the recorder".to_string(),
+        "liquidation_stream_connect" => {
+            "forceOrder stream reconnects are failing; restart the recorder and verify Binance futures connectivity".to_string()
+        }
+        "market_stream_connect" => {
+            "symbol stream reconnects are failing; restart the recorder and verify watched symbols and network".to_string()
+        }
+        "postgres_writer" => {
+            "the recorder postgres writer failed; reload postgres env and restart the recorder".to_string()
+        }
+        "process_exit" => "the recorder process exited; inspect recent recorder logs and restart it".to_string(),
+        "recorder_down" => "heartbeat and market tables are stale; the recorder is likely stopped or hung".to_string(),
+        "market_data_stale" => "market tables are stale even though the process still emits logs; restart the recorder".to_string(),
+        "liquidation_stale" => "liquidation data exceeded the configured age threshold".to_string(),
+        _ => "watchdog found a stale or failed recorder state; inspect the recent recorder errors".to_string(),
+    };
+
+    Diagnosis {
+        category: category.to_string(),
+        summary,
+    }
+}
+
+fn contains_any(haystack: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| haystack.contains(needle))
+}
+
+fn read_log_snapshot(path: &PathBuf) -> Result<LogSnapshot, Box<dyn std::error::Error>> {
+    if !path.exists() {
+        return Ok(LogSnapshot {
+            last_heartbeat: None,
+            recent_errors: vec![format!("heartbeat log missing: {}", path.display())],
+        });
+    }
+
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+    let mut tail = VecDeque::with_capacity(256);
+    for line in reader.lines() {
+        let line = line?;
+        if tail.len() == 256 {
+            tail.pop_front();
+        }
+        tail.push_back(line);
+    }
+
+    let mut last_heartbeat = None;
+    let mut last_heartbeat_at = None;
+    let mut recent_errors = Vec::new();
+
+    for line in tail.into_iter().rev() {
+        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        if last_heartbeat.is_none()
+            && value
+                .get("kind")
+                .and_then(Value::as_str)
+                .is_some_and(|kind| kind == "heartbeat")
+        {
+            if let Some((snapshot, heartbeat_at)) = parse_heartbeat(&value) {
+                last_heartbeat = Some(snapshot);
+                last_heartbeat_at = Some(heartbeat_at);
+            }
+        }
+        let level = value
+            .get("level")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let event_time = parse_log_entry_time(&value);
+        if matches!(level, "ERROR" | "WARN") && error_is_relevant(event_time, last_heartbeat_at) {
+            let message = value
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown log message");
+            let mut rendered = message.to_string();
+            if let Some(error) = value.get("error").and_then(Value::as_str) {
+                rendered.push_str(" error=");
+                rendered.push_str(error);
+            }
+            if !recent_errors.contains(&rendered) {
+                recent_errors.push(rendered);
+            }
+            if recent_errors.len() == 5 {
+                break;
+            }
+        }
+    }
+
+    Ok(LogSnapshot {
+        last_heartbeat,
+        recent_errors,
+    })
+}
+
+fn parse_heartbeat(value: &Value) -> Option<(HeartbeatSnapshot, DateTime<Utc>)> {
+    let ping_at = value.get("ping_at")?.as_str()?.to_string();
+    let pong_at = value.get("pong_at")?.as_str()?.to_string();
+    let reader_alive = value
+        .get("reader_alive")
+        .and_then(Value::as_bool)
+        .unwrap_or_else(|| {
+            value
+                .get("worker_alive")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+        });
+    let writer_alive = value
+        .get("writer_alive")
+        .and_then(Value::as_bool)
+        .unwrap_or_else(|| {
+            value
+                .get("worker_alive")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+        });
+    let worker_alive = value
+        .get("worker_alive")
+        .and_then(Value::as_bool)
+        .unwrap_or(reader_alive && writer_alive);
+    let watched_symbols = value
+        .get("watched_symbols")
+        .and_then(Value::as_str)
+        .map(|raw| {
+            raw.split(',')
+                .map(str::trim)
+                .filter(|symbol| !symbol.is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let heartbeat_at = parse_datetime_text(&pong_at)?;
+    let heartbeat_age_sec = Some((Utc::now() - heartbeat_at).num_seconds());
+    Some((
+        HeartbeatSnapshot {
+            ping_at,
+            pong_at,
+            reader_alive,
+            writer_alive,
+            worker_alive,
+            watched_symbols,
+            heartbeat_age_sec,
+        },
+        heartbeat_at,
+    ))
+}
+
+fn parse_log_entry_time(value: &Value) -> Option<DateTime<Utc>> {
+    value
+        .get("timestamp")
+        .and_then(Value::as_str)
+        .and_then(parse_datetime_text)
+}
+
+fn error_is_relevant(
+    event_time: Option<DateTime<Utc>>,
+    last_heartbeat_at: Option<DateTime<Utc>>,
+) -> bool {
+    match (event_time, last_heartbeat_at) {
+        (Some(event_time), Some(last_heartbeat_at)) => event_time >= last_heartbeat_at,
+        _ => true,
+    }
+}
+
+fn age_from_text(value: Option<&str>, now: DateTime<Utc>) -> Option<i64> {
+    let timestamp = parse_datetime_text(value?)?;
+    Some((now - timestamp).num_seconds())
+}
+
+fn parse_datetime_text(value: &str) -> Option<DateTime<Utc>> {
+    if let Ok(timestamp) = DateTime::parse_from_rfc3339(value) {
+        return Some(timestamp.with_timezone(&Utc));
+    }
+
+    let normalized = normalize_postgres_offset(value);
+    DateTime::parse_from_str(&normalized, "%Y-%m-%d %H:%M:%S%.f%z")
+        .or_else(|_| DateTime::parse_from_str(&normalized, "%Y-%m-%d %H:%M:%S%z"))
+        .map(|timestamp: DateTime<FixedOffset>| timestamp.with_timezone(&Utc))
+        .ok()
+}
+
+fn normalize_postgres_offset(value: &str) -> String {
+    if value.len() >= 3 {
+        let suffix = &value[value.len() - 3..];
+        let bytes = suffix.as_bytes();
+        if (bytes[0] == b'+' || bytes[0] == b'-')
+            && bytes[1].is_ascii_digit()
+            && bytes[2].is_ascii_digit()
+        {
+            return format!("{value}00");
+        }
+    }
+    value.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        error_is_relevant, infer_diagnosis, normalize_postgres_offset, parse_datetime_text,
+        youngest_age, StalenessReport,
+    };
+
+    #[test]
+    fn parses_postgres_timestamp_without_minutes_in_offset() {
+        let parsed =
+            parse_datetime_text("2026-03-18 01:48:35.447458+00").expect("timestamp should parse");
+        assert_eq!(parsed.to_rfc3339(), "2026-03-18T01:48:35.447458+00:00");
+    }
+
+    #[test]
+    fn appends_minutes_to_short_postgres_offset() {
+        assert_eq!(
+            normalize_postgres_offset("2026-03-18 01:48:35+09"),
+            "2026-03-18 01:48:35+0900"
+        );
+    }
+
+    #[test]
+    fn chooses_youngest_market_age() {
+        assert_eq!(youngest_age(Some(15), Some(9)), Some(9));
+        assert_eq!(youngest_age(Some(15), None), Some(15));
+        assert_eq!(youngest_age(None, None), None);
+    }
+
+    #[test]
+    fn diagnosis_prefers_recent_runtime_error() {
+        let staleness = StalenessReport {
+            market_data_stale: true,
+            heartbeat_stale: true,
+            liquidation_stale: false,
+            reasons: vec!["market_data_age_exceeded".to_string()],
+            recent_errors: vec!["failed to connect symbol streams error=timeout".to_string()],
+        };
+        let diagnosis = infer_diagnosis(None, &staleness);
+        assert_eq!(diagnosis.category, "market_stream_connect");
+    }
+
+    #[test]
+    fn diagnosis_flags_missing_postgres_config() {
+        let staleness = StalenessReport {
+            market_data_stale: true,
+            heartbeat_stale: false,
+            liquidation_stale: false,
+            reasons: vec![],
+            recent_errors: vec![],
+        };
+        let diagnosis = infer_diagnosis(
+            Some("postgres URL missing; set SANDBOX_QUANT_POSTGRES_URL"),
+            &staleness,
+        );
+        assert_eq!(diagnosis.category, "postgres_config");
+    }
+
+    #[test]
+    fn diagnosis_is_healthy_when_no_staleness_flags_are_set() {
+        let staleness = StalenessReport {
+            market_data_stale: false,
+            heartbeat_stale: false,
+            liquidation_stale: false,
+            reasons: vec![],
+            recent_errors: vec!["process failed error=old".to_string()],
+        };
+        let diagnosis = infer_diagnosis(None, &staleness);
+        assert_eq!(diagnosis.category, "healthy");
+    }
+
+    #[test]
+    fn relevant_errors_must_be_newer_than_latest_heartbeat() {
+        let heartbeat_at =
+            parse_datetime_text("2026-03-18T03:04:10.554027+00:00").expect("heartbeat time");
+        let old_error =
+            parse_datetime_text("2026-03-18T03:03:59.000000+00:00").expect("old error time");
+        let new_error =
+            parse_datetime_text("2026-03-18T03:04:11.000000+00:00").expect("new error time");
+        assert!(!error_is_relevant(Some(old_error), Some(heartbeat_at)));
+        assert!(error_is_relevant(Some(new_error), Some(heartbeat_at)));
+    }
+}

--- a/src/charting/adapters/sandbox.rs
+++ b/src/charting/adapters/sandbox.rs
@@ -17,9 +17,11 @@ const ENTRY: RgbColor = RgbColor::new(90, 170, 255);
 const TAKE_PROFIT: RgbColor = RgbColor::new(80, 220, 140);
 const STOP_LOSS: RgbColor = RgbColor::new(255, 90, 90);
 const OPEN_AT_END: RgbColor = RgbColor::new(240, 220, 120);
+const SIGNAL_EXIT: RgbColor = RgbColor::new(200, 200, 255);
 const EQUITY: RgbColor = RgbColor::new(120, 180, 255);
 const VOLUME_UP: RgbColor = RgbColor::new(70, 150, 110);
 const VOLUME_DOWN: RgbColor = RgbColor::new(160, 90, 90);
+const SECONDARY_LINE: RgbColor = RgbColor::new(255, 215, 90);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MarketTimeframe {
@@ -34,6 +36,40 @@ pub enum MarketTimeframe {
     Week1w,
     Day1d,
     Month1mo,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MarketSeriesKind {
+    Candles,
+    MidPrice,
+    CloseLine,
+    Ema20,
+    Vwap,
+    Liquidations,
+}
+
+impl MarketSeriesKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Candles => "Candles",
+            Self::MidPrice => "Mid-price",
+            Self::CloseLine => "Close line",
+            Self::Ema20 => "EMA 20",
+            Self::Vwap => "VWAP",
+            Self::Liquidations => "Liquidations",
+        }
+    }
+
+    pub fn all() -> [Self; 6] {
+        [
+            Self::Candles,
+            Self::MidPrice,
+            Self::CloseLine,
+            Self::Ema20,
+            Self::Vwap,
+            Self::Liquidations,
+        ]
+    }
 }
 
 impl MarketTimeframe {
@@ -111,6 +147,31 @@ pub fn market_scene_from_snapshot_with_timeframe(
     snapshot: &DashboardSnapshot,
     timeframe: MarketTimeframe,
 ) -> ChartScene {
+    build_market_scene(
+        snapshot,
+        timeframe,
+        MarketSeriesKind::Candles,
+        Some(MarketSeriesKind::MidPrice),
+        true,
+    )
+}
+
+pub fn market_scene_from_snapshot_with_overlay(
+    snapshot: &DashboardSnapshot,
+    timeframe: MarketTimeframe,
+    primary: MarketSeriesKind,
+    secondary: Option<MarketSeriesKind>,
+) -> ChartScene {
+    build_market_scene(snapshot, timeframe, primary, secondary, false)
+}
+
+fn build_market_scene(
+    snapshot: &DashboardSnapshot,
+    timeframe: MarketTimeframe,
+    primary: MarketSeriesKind,
+    secondary: Option<MarketSeriesKind>,
+    include_default_annotations: bool,
+) -> ChartScene {
     let effective_timeframe = snapshot
         .market_series
         .kline_interval
@@ -118,75 +179,45 @@ pub fn market_scene_from_snapshot_with_timeframe(
         .and_then(MarketTimeframe::from_interval_label)
         .filter(|source| source.rank() > timeframe.rank())
         .unwrap_or(timeframe);
-    let mut price_series = Vec::new();
-    if !snapshot.market_series.book_tickers.is_empty() {
-        price_series.extend(sampled_mid_price_segments(snapshot, 2_400, 60_000, 1));
-    }
     let display_klines =
         aggregate_klines_for_timeframe(&snapshot.market_series.klines, effective_timeframe);
-    if !display_klines.is_empty() {
-        price_series.push(Series::Candles(CandleSeries {
-            name: "candles".to_string(),
-            up_color: None,
-            down_color: None,
-            candles: display_klines
-                .iter()
-                .map(|row| Candle {
-                    open_time_ms: EpochMs::from(row.open_time_ms),
-                    close_time_ms: EpochMs::from(row.close_time_ms),
-                    open: row.open,
-                    high: row.high,
-                    low: row.low,
-                    close: row.close,
-                })
-                .collect(),
-        }));
-    } else if price_series.is_empty() {
-        price_series.extend(sampled_mid_price_segments(snapshot, 2_400, 60_000, 2));
+    let mut price_series = build_overlay_series(snapshot, &display_klines, primary, false);
+    if let Some(secondary) = secondary.filter(|kind| *kind != primary) {
+        price_series.extend(build_overlay_series(
+            snapshot,
+            &display_klines,
+            secondary,
+            true,
+        ));
     }
 
-    let mut markers = snapshot
-        .market_series
-        .liquidations
-        .iter()
-        .map(|row| Marker {
-            label: row.force_side.clone(),
-            time_ms: EpochMs::from(row.event_time_ms),
-            value: row.price,
-            color: if row.force_side == "BUY" {
-                LIQ_BUY
-            } else {
-                LIQ_OTHER
-            },
-            size: ((row.notional.max(1.0)).log10().clamp(0.0, 7.0) as i32) + 3,
-            shape: MarkerShape::Circle,
-        })
-        .collect::<Vec<_>>();
+    if include_default_annotations {
+        let mut markers = liquidation_marker_series(snapshot);
+        if let Some(report) = snapshot
+            .selected_report
+            .as_ref()
+            .filter(|report| report.instrument == snapshot.symbol)
+        {
+            markers.extend(
+                VisualizationService::signal_markers(&report.trades)
+                    .into_iter()
+                    .map(|marker| Marker {
+                        label: marker.label,
+                        time_ms: EpochMs::from(marker.time_ms),
+                        value: marker.price,
+                        color: signal_color(marker.kind),
+                        size: 8,
+                        shape: MarkerShape::Cross,
+                    }),
+            );
+        }
 
-    if let Some(report) = snapshot
-        .selected_report
-        .as_ref()
-        .filter(|report| report.instrument == snapshot.symbol)
-    {
-        markers.extend(
-            VisualizationService::signal_markers(&report.trades)
-                .into_iter()
-                .map(|marker| Marker {
-                    label: marker.label,
-                    time_ms: EpochMs::from(marker.time_ms),
-                    value: marker.price,
-                    color: signal_color(marker.kind),
-                    size: 8,
-                    shape: MarkerShape::Cross,
-                }),
-        );
-    }
-
-    if !markers.is_empty() {
-        price_series.push(Series::Markers(MarkerSeries {
-            name: "signals".to_string(),
-            markers,
-        }));
+        if !markers.is_empty() {
+            price_series.push(Series::Markers(MarkerSeries {
+                name: "signals".to_string(),
+                markers,
+            }));
+        }
     }
 
     let mut panes = vec![Pane {
@@ -343,8 +374,167 @@ fn signal_color(kind: SignalKind) -> RgbColor {
         SignalKind::TakeProfit => TAKE_PROFIT,
         SignalKind::StopLoss => STOP_LOSS,
         SignalKind::OpenAtEnd => OPEN_AT_END,
-        SignalKind::SignalExit => STOP_LOSS,
+        SignalKind::SignalExit => SIGNAL_EXIT,
     }
+}
+
+fn build_overlay_series(
+    snapshot: &DashboardSnapshot,
+    display_klines: &[crate::dataset::types::DerivedKlineRow],
+    kind: MarketSeriesKind,
+    secondary: bool,
+) -> Vec<Series> {
+    match kind {
+        MarketSeriesKind::Candles if !display_klines.is_empty() => {
+            vec![Series::Candles(CandleSeries {
+                name: if secondary {
+                    "candles-secondary".to_string()
+                } else {
+                    "candles".to_string()
+                },
+                up_color: None,
+                down_color: None,
+                candles: display_klines
+                    .iter()
+                    .map(|row| Candle {
+                        open_time_ms: EpochMs::from(row.open_time_ms),
+                        close_time_ms: EpochMs::from(row.close_time_ms),
+                        open: row.open,
+                        high: row.high,
+                        low: row.low,
+                        close: row.close,
+                    })
+                    .collect(),
+            })]
+        }
+        MarketSeriesKind::MidPrice => {
+            sampled_mid_price_segments(snapshot, 2_400, 60_000, if secondary { 2 } else { 1 })
+        }
+        MarketSeriesKind::CloseLine if !display_klines.is_empty() => {
+            vec![Series::Line(LineSeries {
+                name: if secondary {
+                    "close-secondary".to_string()
+                } else {
+                    "close".to_string()
+                },
+                color: if secondary { SECONDARY_LINE } else { PRICE },
+                width: if secondary { 2 } else { 1 },
+                points: display_klines
+                    .iter()
+                    .map(|row| LinePoint {
+                        time_ms: EpochMs::from(row.close_time_ms),
+                        value: row.close,
+                    })
+                    .collect(),
+            })]
+        }
+        MarketSeriesKind::Ema20 if !display_klines.is_empty() => {
+            let points = ema_points(display_klines, 20);
+            if points.is_empty() {
+                Vec::new()
+            } else {
+                vec![Series::Line(LineSeries {
+                    name: if secondary {
+                        "ema20-secondary".to_string()
+                    } else {
+                        "ema20".to_string()
+                    },
+                    color: if secondary { SECONDARY_LINE } else { PRICE },
+                    width: 2,
+                    points,
+                })]
+            }
+        }
+        MarketSeriesKind::Vwap if !display_klines.is_empty() => {
+            let points = vwap_points(display_klines);
+            if points.is_empty() {
+                Vec::new()
+            } else {
+                vec![Series::Line(LineSeries {
+                    name: if secondary {
+                        "vwap-secondary".to_string()
+                    } else {
+                        "vwap".to_string()
+                    },
+                    color: if secondary { SECONDARY_LINE } else { PRICE },
+                    width: 2,
+                    points,
+                })]
+            }
+        }
+        MarketSeriesKind::Liquidations => {
+            let markers = liquidation_marker_series(snapshot);
+            if markers.is_empty() {
+                Vec::new()
+            } else {
+                vec![Series::Markers(MarkerSeries {
+                    name: if secondary {
+                        "liquidations-secondary".to_string()
+                    } else {
+                        "liquidations".to_string()
+                    },
+                    markers,
+                })]
+            }
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn liquidation_marker_series(snapshot: &DashboardSnapshot) -> Vec<Marker> {
+    snapshot
+        .market_series
+        .liquidations
+        .iter()
+        .map(|row| Marker {
+            label: row.force_side.clone(),
+            time_ms: EpochMs::from(row.event_time_ms),
+            value: row.price,
+            color: if row.force_side == "BUY" {
+                LIQ_BUY
+            } else {
+                LIQ_OTHER
+            },
+            size: ((row.notional.max(1.0)).log10().clamp(0.0, 7.0) as i32) + 3,
+            shape: MarkerShape::Circle,
+        })
+        .collect()
+}
+
+fn ema_points(
+    display_klines: &[crate::dataset::types::DerivedKlineRow],
+    period: usize,
+) -> Vec<LinePoint> {
+    if display_klines.is_empty() {
+        return Vec::new();
+    }
+    let alpha = 2.0 / (period as f64 + 1.0);
+    let mut ema = display_klines[0].close;
+    display_klines
+        .iter()
+        .map(|row| {
+            ema = row.close * alpha + ema * (1.0 - alpha);
+            LinePoint {
+                time_ms: EpochMs::from(row.close_time_ms),
+                value: ema,
+            }
+        })
+        .collect()
+}
+
+fn vwap_points(display_klines: &[crate::dataset::types::DerivedKlineRow]) -> Vec<LinePoint> {
+    let mut cumulative_quote = 0.0;
+    let mut cumulative_volume = 0.0;
+    let mut points = Vec::new();
+    for row in display_klines {
+        cumulative_quote += row.quote_volume;
+        cumulative_volume += row.volume.max(f64::EPSILON);
+        points.push(LinePoint {
+            time_ms: EpochMs::from(row.close_time_ms),
+            value: cumulative_quote / cumulative_volume,
+        });
+    }
+    points
 }
 
 fn usdt_axis(decimals: u8, include_zero: bool) -> YAxisSpec {

--- a/src/collector_app/binance_public.rs
+++ b/src/collector_app/binance_public.rs
@@ -11,7 +11,7 @@ use crate::record::coordination::RecorderCoordination;
 use crate::storage::postgres_market_data::{
     connect as connect_postgres, init_schema as init_postgres_schema, insert_kline,
     insert_liquidation, mask_postgres_url, CollectorStorageBackend, PostgresKlineRecord,
-    PostgresLiquidationRecord,
+    PostgresLiquidationRecord, SHARED_MARKET_DATA_MODE,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -275,7 +275,7 @@ fn import_liquidation_snapshot_bytes_duckdb(
                  )",
                 params![
                     next_id,
-                    record.mode,
+                    mode.as_str(),
                     record.symbol,
                     record.event_time_ms,
                     record.receive_time_ms,
@@ -314,7 +314,7 @@ fn import_liquidation_snapshot_bytes_postgres(
 }
 
 fn parse_liquidation_line(
-    mode: BinanceMode,
+    _mode: BinanceMode,
     product: BinancePublicProduct,
     symbol: &str,
     line: &str,
@@ -336,7 +336,6 @@ fn parse_liquidation_line(
         limit_price
     };
     Ok(PostgresLiquidationRecord {
-        mode: mode.as_str().to_string(),
         product: product.as_str().to_string(),
         symbol: symbol.to_string(),
         event_time_ms: time_ms,
@@ -365,6 +364,7 @@ fn import_kline_bytes_duckdb(
     let csv = first_zip_csv(bytes)?;
     let mut rows = 0usize;
     let mut next_id = next_kline_id(connection)?;
+    let shared_mode = SHARED_MARKET_DATA_MODE.to_string();
     for line in csv.lines() {
         if line.trim().is_empty() || line.starts_with("open_time,") {
             continue;
@@ -382,7 +382,7 @@ fn import_kline_bytes_duckdb(
                  )",
                 params![
                     next_id,
-                    record.mode,
+                    shared_mode.clone(),
                     record.product,
                     record.symbol,
                     record.interval_name,
@@ -429,7 +429,7 @@ fn import_kline_bytes_postgres(
 }
 
 fn parse_kline_line(
-    mode: BinanceMode,
+    _mode: BinanceMode,
     product: BinancePublicProduct,
     symbol: &str,
     interval: &str,
@@ -442,7 +442,6 @@ fn parse_kline_line(
         });
     }
     Ok(PostgresKlineRecord {
-        mode: mode.as_str().to_string(),
         product: product.as_str().to_string(),
         symbol: symbol.to_string(),
         interval_name: interval.to_string(),

--- a/src/command/backtest.rs
+++ b/src/command/backtest.rs
@@ -13,11 +13,23 @@ pub enum BacktestCommand {
         from: NaiveDate,
         to: NaiveDate,
     },
+    Sweep {
+        templates: Vec<StrategyTemplate>,
+        instruments: Vec<String>,
+        windows: Vec<BacktestSweepWindow>,
+        output_dir: String,
+    },
     List,
     ReportLatest,
     ReportShow {
         run_id: i64,
     },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BacktestSweepWindow {
+    pub from: NaiveDate,
+    pub to: NaiveDate,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -30,7 +42,7 @@ pub enum BacktestShellInput {
 }
 
 pub fn backtest_help_text() -> &'static str {
-    "/run <template> <instrument> --from <YYYY-MM-DD> --to <YYYY-MM-DD>\n/list\n/report latest\n/report show <run_id>\n/mode <real|demo>\n/help\n/exit"
+    "/run <template> <instrument> --from <YYYY-MM-DD> --to <YYYY-MM-DD>\n/sweep --templates <csv> --instruments <csv> --windows <from:to,...> [--output-dir <path>]\n/list\n/report latest\n/report show <run_id>\n/mode <real|demo>\n/help\n/exit"
 }
 
 pub fn parse_backtest_shell_input(line: &str) -> Result<BacktestShellInput, String> {
@@ -68,6 +80,10 @@ pub fn parse_backtest_command(args: &[String]) -> Result<BacktestCommand, String
         Some("run") => {
             let template = match args.get(1).map(String::as_str) {
                 Some("liquidation-breakdown-short") => StrategyTemplate::LiquidationBreakdownShort,
+                Some("price-sma-cross-long") => StrategyTemplate::PriceSmaCrossLong,
+                Some("price-sma-cross-short") => StrategyTemplate::PriceSmaCrossShort,
+                Some("price-sma-cross-long-fast") => StrategyTemplate::PriceSmaCrossLongFast,
+                Some("price-sma-cross-short-fast") => StrategyTemplate::PriceSmaCrossShortFast,
                 Some(other) => return Err(format!("unsupported template: {other}")),
                 None => {
                     return Err(
@@ -87,6 +103,7 @@ pub fn parse_backtest_command(args: &[String]) -> Result<BacktestCommand, String
                 to,
             })
         }
+        Some("sweep") => parse_backtest_sweep_command(&args[1..]),
         Some("list") => {
             if args.len() == 1 {
                 Ok(BacktestCommand::List)
@@ -148,12 +165,124 @@ pub fn complete_backtest_input(line: &str) -> Vec<ShellCompletion> {
                 )
             })
             .collect(),
+        Some("sweep") => vec![completion(
+            "/sweep --templates price-sma-cross-long,price-sma-cross-short --instruments BTCUSDT,ETHUSDT --windows 2026-03-01:2026-03-15",
+            "run a backtest sweep and export to PostgreSQL",
+        )],
         Some("report") if parts.len() <= 2 => vec![
             completion("/report latest", "show latest stored run"),
             completion("/report show ", "show a stored run by id"),
         ],
         _ => Vec::new(),
     }
+}
+
+fn parse_backtest_sweep_command(args: &[String]) -> Result<BacktestCommand, String> {
+    let mut templates = None;
+    let mut instruments = None;
+    let mut windows = None;
+    let mut output_dir = "var/backtest-sweeps".to_string();
+    let mut index = 0usize;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--templates" => {
+                let value = args.get(index + 1).ok_or("missing value for --templates")?;
+                templates = Some(parse_templates_csv(value)?);
+                index += 2;
+            }
+            "--instruments" => {
+                let value = args
+                    .get(index + 1)
+                    .ok_or("missing value for --instruments")?;
+                instruments = Some(parse_instruments_csv(value));
+                index += 2;
+            }
+            "--windows" => {
+                let value = args.get(index + 1).ok_or("missing value for --windows")?;
+                windows = Some(parse_windows_csv(value)?);
+                index += 2;
+            }
+            "--output-dir" => {
+                let value = args.get(index + 1).ok_or("missing value for --output-dir")?;
+                output_dir = value.clone();
+                index += 2;
+            }
+            other => return Err(format!("unsupported arg: {other}")),
+        }
+    }
+
+    let templates = templates.ok_or(
+        "usage: sweep --templates <csv> --instruments <csv> --windows <from:to,...> [--output-dir <path>]",
+    )?;
+    let instruments = instruments.ok_or(
+        "usage: sweep --templates <csv> --instruments <csv> --windows <from:to,...> [--output-dir <path>]",
+    )?;
+    let windows = windows.ok_or(
+        "usage: sweep --templates <csv> --instruments <csv> --windows <from:to,...> [--output-dir <path>]",
+    )?;
+
+    Ok(BacktestCommand::Sweep {
+        templates,
+        instruments,
+        windows,
+        output_dir,
+    })
+}
+
+fn parse_templates_csv(raw: &str) -> Result<Vec<StrategyTemplate>, String> {
+    let mut templates = Vec::new();
+    for value in raw.split(',').map(str::trim).filter(|value| !value.is_empty()) {
+        let template = match value {
+            "liquidation-breakdown-short" => StrategyTemplate::LiquidationBreakdownShort,
+            "price-sma-cross-long" => StrategyTemplate::PriceSmaCrossLong,
+            "price-sma-cross-short" => StrategyTemplate::PriceSmaCrossShort,
+            "price-sma-cross-long-fast" => StrategyTemplate::PriceSmaCrossLongFast,
+            "price-sma-cross-short-fast" => StrategyTemplate::PriceSmaCrossShortFast,
+            other => return Err(format!("unsupported template: {other}")),
+        };
+        if !templates.contains(&template) {
+            templates.push(template);
+        }
+    }
+    if templates.is_empty() {
+        return Err("no templates provided".to_string());
+    }
+    Ok(templates)
+}
+
+fn parse_instruments_csv(raw: &str) -> Vec<String> {
+    let mut instruments = raw
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(normalize_instrument_symbol)
+        .collect::<Vec<_>>();
+    instruments.sort();
+    instruments.dedup();
+    instruments
+}
+
+fn parse_windows_csv(raw: &str) -> Result<Vec<BacktestSweepWindow>, String> {
+    let mut windows = Vec::new();
+    for value in raw.split(',').map(str::trim).filter(|value| !value.is_empty()) {
+        let Some((from_raw, to_raw)) = value.split_once(':') else {
+            return Err(format!("invalid window: {value}. expected <from:to>"));
+        };
+        let from = NaiveDate::parse_from_str(from_raw, "%Y-%m-%d")
+            .map_err(|_| format!("invalid date: {from_raw}"))?;
+        let to = NaiveDate::parse_from_str(to_raw, "%Y-%m-%d")
+            .map_err(|_| format!("invalid date: {to_raw}"))?;
+        if from > to {
+            return Err(format!(
+                "invalid date range: from ({from}) must be on or before to ({to})"
+            ));
+        }
+        windows.push(BacktestSweepWindow { from, to });
+    }
+    if windows.is_empty() {
+        return Err("no windows provided".to_string());
+    }
+    Ok(windows)
 }
 
 fn parse_dates(args: &[String]) -> Result<(NaiveDate, NaiveDate), String> {
@@ -243,6 +372,143 @@ mod tests {
                 instrument: "BTCUSDT".to_string(),
                 from: NaiveDate::from_ymd_opt(2026, 3, 13).expect("date"),
                 to: NaiveDate::from_ymd_opt(2026, 3, 14).expect("date"),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_backtest_command_accepts_price_sma_template() {
+        let args = vec![
+            "run".to_string(),
+            "price-sma-cross-long".to_string(),
+            "ethusdt".to_string(),
+            "--from".to_string(),
+            "2026-03-13".to_string(),
+            "--to".to_string(),
+            "2026-03-14".to_string(),
+        ];
+
+        let command = parse_backtest_command(&args).expect("valid run command");
+
+        assert_eq!(
+            command,
+            BacktestCommand::Run {
+                template: StrategyTemplate::PriceSmaCrossLong,
+                instrument: "ETHUSDT".to_string(),
+                from: NaiveDate::from_ymd_opt(2026, 3, 13).expect("date"),
+                to: NaiveDate::from_ymd_opt(2026, 3, 14).expect("date"),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_backtest_command_accepts_price_sma_short_template() {
+        let args = vec![
+            "run".to_string(),
+            "price-sma-cross-short".to_string(),
+            "xrpusdt".to_string(),
+            "--from".to_string(),
+            "2026-03-13".to_string(),
+            "--to".to_string(),
+            "2026-03-14".to_string(),
+        ];
+
+        let command = parse_backtest_command(&args).expect("valid run command");
+
+        assert_eq!(
+            command,
+            BacktestCommand::Run {
+                template: StrategyTemplate::PriceSmaCrossShort,
+                instrument: "XRPUSDT".to_string(),
+                from: NaiveDate::from_ymd_opt(2026, 3, 13).expect("date"),
+                to: NaiveDate::from_ymd_opt(2026, 3, 14).expect("date"),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_backtest_command_accepts_price_sma_long_fast_template() {
+        let args = vec![
+            "run".to_string(),
+            "price-sma-cross-long-fast".to_string(),
+            "solusdt".to_string(),
+            "--from".to_string(),
+            "2026-03-13".to_string(),
+            "--to".to_string(),
+            "2026-03-14".to_string(),
+        ];
+
+        let command = parse_backtest_command(&args).expect("valid run command");
+
+        assert_eq!(
+            command,
+            BacktestCommand::Run {
+                template: StrategyTemplate::PriceSmaCrossLongFast,
+                instrument: "SOLUSDT".to_string(),
+                from: NaiveDate::from_ymd_opt(2026, 3, 13).expect("date"),
+                to: NaiveDate::from_ymd_opt(2026, 3, 14).expect("date"),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_backtest_command_accepts_price_sma_short_fast_template() {
+        let args = vec![
+            "run".to_string(),
+            "price-sma-cross-short-fast".to_string(),
+            "bnbusdt".to_string(),
+            "--from".to_string(),
+            "2026-03-13".to_string(),
+            "--to".to_string(),
+            "2026-03-14".to_string(),
+        ];
+
+        let command = parse_backtest_command(&args).expect("valid run command");
+
+        assert_eq!(
+            command,
+            BacktestCommand::Run {
+                template: StrategyTemplate::PriceSmaCrossShortFast,
+                instrument: "BNBUSDT".to_string(),
+                from: NaiveDate::from_ymd_opt(2026, 3, 13).expect("date"),
+                to: NaiveDate::from_ymd_opt(2026, 3, 14).expect("date"),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_backtest_command_accepts_sweep() {
+        let args = vec![
+            "sweep".to_string(),
+            "--templates".to_string(),
+            "price-sma-cross-long,price-sma-cross-short-fast".to_string(),
+            "--instruments".to_string(),
+            "btcusdt,ethusdt".to_string(),
+            "--windows".to_string(),
+            "2026-03-01:2026-03-15,2026-03-16:2026-03-18".to_string(),
+            "--output-dir".to_string(),
+            "var/backtest-sweeps".to_string(),
+        ];
+
+        assert_eq!(
+            parse_backtest_command(&args).unwrap(),
+            BacktestCommand::Sweep {
+                templates: vec![
+                    StrategyTemplate::PriceSmaCrossLong,
+                    StrategyTemplate::PriceSmaCrossShortFast,
+                ],
+                instruments: vec!["BTCUSDT".to_string(), "ETHUSDT".to_string()],
+                windows: vec![
+                    BacktestSweepWindow {
+                        from: NaiveDate::from_ymd_opt(2026, 3, 1).unwrap(),
+                        to: NaiveDate::from_ymd_opt(2026, 3, 15).unwrap(),
+                    },
+                    BacktestSweepWindow {
+                        from: NaiveDate::from_ymd_opt(2026, 3, 16).unwrap(),
+                        to: NaiveDate::from_ymd_opt(2026, 3, 18).unwrap(),
+                    },
+                ],
+                output_dir: "var/backtest-sweeps".to_string(),
             }
         );
     }

--- a/src/command/operator.rs
+++ b/src/command/operator.rs
@@ -169,8 +169,12 @@ fn parse_watch_id(raw: Option<&String>, usage: &str) -> Result<u64, String> {
 fn parse_strategy_template(raw: Option<&String>, usage: &str) -> Result<StrategyTemplate, String> {
     match raw.map(String::as_str) {
         Some("liquidation-breakdown-short") => Ok(StrategyTemplate::LiquidationBreakdownShort),
+        Some("price-sma-cross-long") => Ok(StrategyTemplate::PriceSmaCrossLong),
+        Some("price-sma-cross-short") => Ok(StrategyTemplate::PriceSmaCrossShort),
+        Some("price-sma-cross-long-fast") => Ok(StrategyTemplate::PriceSmaCrossLongFast),
+        Some("price-sma-cross-short-fast") => Ok(StrategyTemplate::PriceSmaCrossShortFast),
         Some(other) => Err(format!(
-            "unsupported strategy template: {other}. expected liquidation-breakdown-short"
+            "unsupported strategy template: {other}. expected liquidation-breakdown-short, price-sma-cross-long, price-sma-cross-short, price-sma-cross-long-fast, or price-sma-cross-short-fast"
         )),
         None => Err(usage.to_string()),
     }

--- a/src/command/recorder.rs
+++ b/src/command/recorder.rs
@@ -19,7 +19,7 @@ pub enum RecorderShellInput {
 }
 
 pub fn recorder_help_text() -> &'static str {
-    "/start [symbols...]\n/status\n/stop\n/mode <real|demo>\n/help\n/exit"
+    "/start [symbols...]\n  symbols are optional; liquidation events stream globally, symbols add bookTicker/aggTrade\n/status\n/stop\n/mode <real|demo>\n/help\n/exit"
 }
 
 pub fn parse_recorder_shell_input(line: &str) -> Result<RecorderShellInput, String> {
@@ -87,7 +87,10 @@ pub fn complete_recorder_input(line: &str) -> Vec<ShellCompletion> {
 
     if parts.is_empty() {
         return vec![
-            completion("/start", "start recorder with optional symbols"),
+            completion(
+                "/start",
+                "start recorder; symbols only scope bookTicker and aggTrade streams",
+            ),
             completion("/status", "show recorder status"),
             completion("/stop", "stop recorder"),
             completion("/mode", "switch mode"),

--- a/src/dataset/query.rs
+++ b/src/dataset/query.rs
@@ -773,6 +773,9 @@ fn parse_template(raw: &str) -> Result<StrategyTemplate, StorageError> {
     match raw {
         "liquidation-breakdown-short" => Ok(StrategyTemplate::LiquidationBreakdownShort),
         "price-sma-cross-long" => Ok(StrategyTemplate::PriceSmaCrossLong),
+        "price-sma-cross-short" => Ok(StrategyTemplate::PriceSmaCrossShort),
+        "price-sma-cross-long-fast" => Ok(StrategyTemplate::PriceSmaCrossLongFast),
+        "price-sma-cross-short-fast" => Ok(StrategyTemplate::PriceSmaCrossShortFast),
         other => Err(StorageError::WriteFailedWithContext {
             message: format!("unsupported backtest template: {other}"),
         }),

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -3,7 +3,8 @@ use eframe::egui::{self, vec2, Color32, ComboBox, Grid, RichText, SidePanel, Top
 use crate::app::bootstrap::BinanceMode;
 use crate::backtest_app::runner::{BacktestConfig, BacktestReport};
 use crate::charting::adapters::sandbox::{
-    equity_scene_from_report, market_scene_from_snapshot_with_timeframe, MarketTimeframe,
+    equity_scene_from_report, market_scene_from_snapshot_with_overlay,
+    market_scene_from_snapshot_with_timeframe, MarketSeriesKind, MarketTimeframe,
 };
 use crate::charting::egui::RetainedChartTexture;
 use crate::charting::inspect::{hover_model_at, pan_scene, visible_time_bounds, zoom_scene};
@@ -64,10 +65,24 @@ pub struct SandboxQuantGuiApp {
     equity_chart: RetainedChartTexture,
     market_viewport: Viewport,
     equity_viewport: Viewport,
+    custom_charts: Vec<CustomChartPanel>,
+    next_chart_id: u32,
+}
+
+struct CustomChartPanel {
+    id: u32,
+    title: String,
+    symbol: String,
+    timeframe: MarketTimeframe,
+    primary: MarketSeriesKind,
+    secondary: Option<MarketSeriesKind>,
+    viewport: Viewport,
+    texture: RetainedChartTexture,
 }
 
 impl SandboxQuantGuiApp {
     pub fn new(launch: GuiLaunchConfig) -> Self {
+        let launch_symbol = launch.symbol.clone();
         let mut app = Self {
             service: VisualizationService,
             mode: launch.mode,
@@ -85,6 +100,17 @@ impl SandboxQuantGuiApp {
             equity_chart: RetainedChartTexture::default(),
             market_viewport: Viewport::default(),
             equity_viewport: Viewport::default(),
+            custom_charts: vec![CustomChartPanel {
+                id: 1,
+                title: "Market Chart 1".to_string(),
+                symbol: launch_symbol,
+                timeframe: launch.market_timeframe,
+                primary: MarketSeriesKind::Candles,
+                secondary: Some(MarketSeriesKind::MidPrice),
+                viewport: Viewport::default(),
+                texture: RetainedChartTexture::default(),
+            }],
+            next_chart_id: 2,
         };
         app.refresh_dashboard(None);
         app
@@ -107,6 +133,50 @@ impl SandboxQuantGuiApp {
         let today = chrono::Utc::now().date_naive();
         self.from_input = (today - chrono::Days::new(days.saturating_sub(1))).to_string();
         self.to_input = today.to_string();
+    }
+
+    fn add_custom_chart_panel(&mut self) {
+        self.custom_charts.push(CustomChartPanel {
+            id: self.next_chart_id,
+            title: format!("Market Chart {}", self.next_chart_id),
+            symbol: self.symbol_input.trim().to_ascii_uppercase(),
+            timeframe: self.market_timeframe,
+            primary: MarketSeriesKind::Candles,
+            secondary: Some(MarketSeriesKind::MidPrice),
+            viewport: Viewport::default(),
+            texture: RetainedChartTexture::default(),
+        });
+        self.next_chart_id += 1;
+    }
+
+    fn load_snapshot_for_symbol(&self, symbol: &str) -> Result<DashboardSnapshot, String> {
+        self.service
+            .load_dashboard(DashboardQuery {
+                mode: self.mode,
+                base_dir: self.base_dir_input.trim().into(),
+                symbol: symbol.to_ascii_uppercase(),
+                from: parse_date("from", &self.from_input)?,
+                to: parse_date("to", &self.to_input)?,
+                selected_run_id: None,
+                run_limit: self.run_limit,
+            })
+            .map_err(|error| error.to_string())
+    }
+
+    fn duplicate_custom_chart_panel(&mut self, index: usize) {
+        if let Some(source) = self.custom_charts.get(index) {
+            self.custom_charts.push(CustomChartPanel {
+                id: self.next_chart_id,
+                title: format!("{} Copy", source.title),
+                symbol: source.symbol.clone(),
+                timeframe: source.timeframe,
+                primary: source.primary,
+                secondary: source.secondary,
+                viewport: source.viewport.clone(),
+                texture: RetainedChartTexture::default(),
+            });
+            self.next_chart_id += 1;
+        }
     }
 
     fn refresh_dashboard(&mut self, selected_run_id: Option<i64>) {
@@ -318,6 +388,109 @@ impl SandboxQuantGuiApp {
             );
         });
         self.show_market_chart(ui, snapshot, 520.0);
+        ui.separator();
+        ui.horizontal(|ui| {
+            ui.heading("Custom Charts");
+            if ui.button("Add Chart").clicked() {
+                self.add_custom_chart_panel();
+            }
+        });
+        let available_symbols = snapshot.available_symbols.clone();
+        let mut remove_panel = None;
+        let mut duplicate_panel = None;
+        for index in 0..self.custom_charts.len() {
+            let panel_state = {
+                let panel = &self.custom_charts[index];
+                (
+                    panel.id,
+                    panel.symbol.clone(),
+                    panel.timeframe,
+                    panel.primary,
+                    panel.secondary,
+                )
+            };
+            let panel_snapshot = self.load_snapshot_for_symbol(&panel_state.1).ok();
+            let panel = &mut self.custom_charts[index];
+            ui.group(|ui| {
+                ui.horizontal_wrapped(|ui| {
+                    ui.label(format!("Chart #{}", panel.id));
+                    ui.add_sized([180.0, 22.0], egui::TextEdit::singleline(&mut panel.title));
+                    if ui.small_button("Duplicate").clicked() {
+                        duplicate_panel = Some(index);
+                    }
+                    if ui.small_button("Remove").clicked() {
+                        remove_panel = Some(index);
+                    }
+                });
+                ui.small(format!(
+                    "Legend: {}{}",
+                    panel.primary.label(),
+                    panel
+                        .secondary
+                        .map(|kind| format!(" + {}", kind.label()))
+                        .unwrap_or_default()
+                ));
+                ui.horizontal_wrapped(|ui| {
+                    ComboBox::from_id_salt(format!("chart-symbol-{}", panel.id))
+                        .selected_text(if panel.symbol.is_empty() {
+                            "select symbol"
+                        } else {
+                            panel.symbol.as_str()
+                        })
+                        .show_ui(ui, |ui| {
+                            for symbol in &available_symbols {
+                                ui.selectable_value(&mut panel.symbol, symbol.clone(), symbol);
+                            }
+                        });
+                    ComboBox::from_id_salt(format!("chart-timeframe-{}", panel.id))
+                        .selected_text(panel.timeframe.label())
+                        .show_ui(ui, |ui| {
+                            for timeframe in MarketTimeframe::all() {
+                                ui.selectable_value(
+                                    &mut panel.timeframe,
+                                    timeframe,
+                                    timeframe.label(),
+                                );
+                            }
+                        });
+                });
+                ui.horizontal_wrapped(|ui| {
+                    ComboBox::from_id_salt(format!("chart-primary-{}", panel.id))
+                        .selected_text(panel.primary.label())
+                        .show_ui(ui, |ui| {
+                            for kind in MarketSeriesKind::all() {
+                                ui.selectable_value(&mut panel.primary, kind, kind.label());
+                            }
+                        });
+                    ComboBox::from_id_salt(format!("chart-secondary-{}", panel.id))
+                        .selected_text(panel.secondary.map(|kind| kind.label()).unwrap_or("None"))
+                        .show_ui(ui, |ui| {
+                            ui.selectable_value(&mut panel.secondary, None, "None");
+                            for kind in MarketSeriesKind::all() {
+                                ui.selectable_value(&mut panel.secondary, Some(kind), kind.label());
+                            }
+                        });
+                });
+                match panel_snapshot {
+                    Some(panel_snapshot) => {
+                        show_custom_market_chart(ui, &panel_snapshot, panel, 300.0);
+                    }
+                    None => {
+                        ui.colored_label(
+                            Color32::from_rgb(255, 120, 120),
+                            "Unable to load symbol snapshot for this chart panel.",
+                        );
+                    }
+                }
+            });
+            ui.add_space(8.0);
+        }
+        if let Some(index) = duplicate_panel {
+            self.duplicate_custom_chart_panel(index);
+        }
+        if let Some(index) = remove_panel {
+            self.custom_charts.remove(index);
+        }
     }
 
     fn render_pnl(&mut self, ui: &mut Ui, snapshot: &DashboardSnapshot) {
@@ -437,6 +610,53 @@ impl SandboxQuantGuiApp {
             Err(error) => {
                 ui.colored_label(Color32::from_rgb(255, 120, 120), error.to_string());
             }
+        }
+    }
+}
+
+fn show_custom_market_chart(
+    ui: &mut Ui,
+    snapshot: &DashboardSnapshot,
+    panel: &mut CustomChartPanel,
+    height: f32,
+) {
+    let size = vec2(ui.available_width().max(320.0), height);
+    let request = render_request(ui, size);
+    let renderer = PlottersRenderer;
+    let mut scene = market_scene_from_snapshot_with_overlay(
+        snapshot,
+        panel.timeframe,
+        panel.primary,
+        panel.secondary,
+    );
+    if panel.viewport.x_range.is_some() {
+        scene.viewport = panel.viewport.clone();
+    }
+    let interval_label = market_period_unit_label(snapshot, panel.timeframe);
+    render_chart_period_label(ui, &scene, &interval_label);
+    match renderer.render(&scene, &request) {
+        Ok(frame) => {
+            panel.texture.update(
+                ui.ctx(),
+                format!("custom-market-chart-{}", panel.id).as_str(),
+                &frame,
+            );
+            if let Some(response) = panel.texture.show(ui, size) {
+                apply_hover(
+                    ui,
+                    &renderer,
+                    &mut scene,
+                    &request,
+                    ChartInteraction {
+                        response,
+                        texture: &mut panel.texture,
+                        viewport: &mut panel.viewport,
+                    },
+                );
+            }
+        }
+        Err(error) => {
+            ui.colored_label(Color32::from_rgb(255, 120, 120), error.to_string());
         }
     }
 }
@@ -1273,5 +1493,28 @@ mod tests {
 
         std::fs::remove_file(db_path).ok();
         std::fs::remove_dir_all(base_dir).ok();
+    }
+
+    #[test]
+    fn duplicate_custom_chart_panel_copies_settings() {
+        let today = chrono::NaiveDate::from_ymd_opt(2026, 3, 13).expect("date");
+        let mut app = SandboxQuantGuiApp::new(GuiLaunchConfig {
+            mode: BinanceMode::Demo,
+            base_dir: "var".to_string(),
+            symbol: "BTCUSDT".to_string(),
+            from: today,
+            to: today,
+            market_timeframe: MarketTimeframe::Minute15m,
+        });
+        app.custom_charts[0].title = "Primary".to_string();
+        app.custom_charts[0].primary = MarketSeriesKind::Ema20;
+        app.custom_charts[0].secondary = Some(MarketSeriesKind::Vwap);
+
+        app.duplicate_custom_chart_panel(0);
+
+        assert_eq!(app.custom_charts.len(), 2);
+        assert_eq!(app.custom_charts[1].title, "Primary Copy");
+        assert_eq!(app.custom_charts[1].primary, MarketSeriesKind::Ema20);
+        assert_eq!(app.custom_charts[1].secondary, Some(MarketSeriesKind::Vwap));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod execution;
 #[cfg(feature = "gui")]
 pub mod gui;
 pub mod market_data;
+pub mod observability;
 pub mod portfolio;
 pub mod record;
 pub mod recorder_app;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,35 +1,641 @@
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use axum::{
+    extract::State,
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use chrono::Utc;
+use reqwest::blocking::Client;
 use sandbox_quant::app::bootstrap::AppBootstrap;
+use sandbox_quant::app::bootstrap::BinanceMode;
+use sandbox_quant::app::commands::AppCommand;
+use sandbox_quant::app::cli::normalize_instrument_symbol;
 use sandbox_quant::app::cli::parse_app_command;
 use sandbox_quant::app::output::render_command_output;
 use sandbox_quant::app::runtime::AppRuntime;
 use sandbox_quant::app::shell::run_shell;
+use sandbox_quant::dataset::query::metrics_for_path;
+use sandbox_quant::domain::exposure::Exposure;
+use sandbox_quant::domain::instrument::Instrument;
+use sandbox_quant::domain::order_type::OrderType;
+use sandbox_quant::exchange::binance::client::BinanceExchange;
+use sandbox_quant::execution::command::{CommandSource, ExecutionCommand};
+use sandbox_quant::observability::logging::init_logging;
 use sandbox_quant::portfolio::store::PortfolioStateStore;
+use sandbox_quant::record::coordination::RecorderCoordination;
+use sandbox_quant::ui::operator_terminal::prompt_status_from_store;
+use serde::Serialize;
+use serde_json::json;
+use tracing::{error, info};
+
+const DEFAULT_TRADING_ENGINE_SERVER_ADDR: &str = "127.0.0.1:9782";
+
+type TradingBootstrap = AppBootstrap<BinanceExchange>;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenvy::dotenv().ok();
 
     let args: Vec<String> = std::env::args().skip(1).collect();
     let mut app = AppBootstrap::from_env(PortfolioStateStore::default())?;
+    let init_mode = app.mode;
+    init_logging("trading-engine", Some(app.mode.as_str()))?;
+    info!(service = "trading-engine", mode = app.mode.as_str(), args = ?args, "process started");
     let mut runtime = AppRuntime::default();
 
-    if args.is_empty() {
-        run_shell(&mut app, &mut runtime)?;
-    } else {
-        let command = parse_app_command(&args)?;
-        let rendered_command = command.clone();
-        runtime.run(&mut app, command)?;
-        println!(
-            "{}",
-            render_command_output(
-                &rendered_command,
-                &app.portfolio_store,
-                &app.price_store,
-                &app.event_log,
-                &app.strategy_store,
-                app.mode,
-            )
-        );
-    }
+    let result: Result<(), Box<dyn std::error::Error>> = match args.first().map(String::as_str) {
+        None => run_interactive(&mut app, &mut runtime, "var"),
+        Some("run") => {
+            let (mode, base_dir) = parse_runtime_args(&args[1..])?;
+            configure_runtime(&mut app, mode, &base_dir)?;
+            run_interactive(&mut app, &mut runtime, &base_dir)
+        }
+        Some("serve") => serve_trading_engine(app, &args[1..]),
+        Some("status") => {
+            print!(
+                "{}",
+                request_trading_engine_server("GET", "/status", parse_server_addr(&args[1..])?)?
+            );
+            Ok(())
+        }
+        Some("health") => {
+            print!(
+                "{}",
+                request_trading_engine_server("GET", "/health", parse_server_addr(&args[1..])?)?
+            );
+            Ok(())
+        }
+        Some("stop") => {
+            print!(
+                "{}",
+                request_trading_engine_server("POST", "/stop", parse_server_addr(&args[1..])?)?
+            );
+            Ok(())
+        }
+        Some(_) => {
+            let command = parse_app_command(&args)?;
+            let rendered_command = command.clone();
+            runtime.run(&mut app, command)?;
+            println!(
+                "{}",
+                render_command_output(
+                    &rendered_command,
+                    &app.portfolio_store,
+                    &app.price_store,
+                    &app.event_log,
+                    &app.strategy_store,
+                    app.mode,
+                )
+            );
+            Ok(())
+        }
+    };
 
+    if let Err(error) = result {
+        error!(service = "trading-engine", mode = init_mode.as_str(), error = %error, "process failed");
+        return Err(error);
+    }
+    info!(
+        service = "trading-engine",
+        mode = init_mode.as_str(),
+        "process completed"
+    );
     Ok(())
+}
+
+struct TradingEngineDaemon {
+    app: TradingBootstrap,
+    runtime: AppRuntime,
+    base_dir: String,
+    last_heartbeat_log: Instant,
+}
+
+#[derive(Clone)]
+struct TradingEngineServerState {
+    daemon: Arc<Mutex<TradingEngineDaemon>>,
+    shutdown: Arc<AtomicBool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TradingEngineServeConfig {
+    mode: BinanceMode,
+    base_dir: String,
+    listen_addr: String,
+}
+
+#[derive(Debug, Serialize)]
+struct TradingEngineHealthResponse {
+    mode: String,
+    state: String,
+    heartbeat_age_sec: i64,
+    portfolio_status: String,
+    positions: usize,
+    open_order_groups: usize,
+    last_event_kind: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct TradingEngineCommandResponse {
+    status: String,
+    rendered: String,
+    mode: String,
+    last_event_kind: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct CloseSymbolRequest {
+    instrument: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct SetTargetExposureRequest {
+    instrument: String,
+    target: f64,
+    order_type: Option<String>,
+    limit_price: Option<f64>,
+}
+
+fn serve_trading_engine(
+    mut app: TradingBootstrap,
+    args: &[String],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = parse_serve_args(args)?;
+    configure_runtime(&mut app, config.mode, &config.base_dir)?;
+    let daemon = Arc::new(Mutex::new(TradingEngineDaemon {
+        app,
+        runtime: AppRuntime::default(),
+        base_dir: config.base_dir.clone(),
+        last_heartbeat_log: Instant::now()
+            .checked_sub(Duration::from_secs(5))
+            .unwrap_or_else(Instant::now),
+    }));
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let state = TradingEngineServerState {
+        daemon: daemon.clone(),
+        shutdown: shutdown.clone(),
+    };
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+
+    runtime.block_on(async move {
+        let app = Router::new()
+            .route("/status", get(trading_engine_status_handler))
+            .route("/health", get(trading_engine_health_handler))
+            .route("/refresh", post(trading_engine_refresh_handler))
+            .route("/close-all", post(trading_engine_close_all_handler))
+            .route("/close-symbol", post(trading_engine_close_symbol_handler))
+            .route(
+                "/set-target-exposure",
+                post(trading_engine_set_target_exposure_handler),
+            )
+            .route("/stop", post(trading_engine_stop_handler))
+            .with_state(state.clone());
+
+        let listener = tokio::net::TcpListener::bind(&config.listen_addr).await?;
+        info!(
+            service = "trading-engine",
+            mode = config.mode.as_str(),
+            listen_addr = %config.listen_addr,
+            "trading-engine control server listening"
+        );
+
+        let supervisor_state = state.clone();
+        let supervisor = tokio::spawn(async move {
+            loop {
+                if supervisor_state.shutdown.load(Ordering::Relaxed) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                let mut daemon = match supervisor_state.daemon.lock() {
+                    Ok(daemon) => daemon,
+                    Err(_) => continue,
+                };
+                if daemon.last_heartbeat_log.elapsed() >= Duration::from_secs(5) {
+                    let db_path =
+                        RecorderCoordination::new(daemon.base_dir.clone()).db_path(daemon.app.mode);
+                    let metrics = metrics_for_path(&db_path).ok();
+                    let last_event_kind = daemon
+                        .app
+                        .event_log
+                        .records
+                        .last()
+                        .map(|record| record.kind.clone())
+                        .unwrap_or_else(|| "none".to_string());
+                    info!(
+                        service = "trading-engine",
+                        kind = "heartbeat",
+                        mode = daemon.app.mode.as_str(),
+                        ping_at = %Utc::now().to_rfc3339(),
+                        pong = "alive",
+                        heartbeat_age_sec = 0,
+                        portfolio_status = %prompt_status_from_store(&daemon.app.portfolio_store),
+                        positions = daemon.app.portfolio_store.snapshot.positions.len(),
+                        open_order_groups = daemon.app.portfolio_store.snapshot.open_orders.len(),
+                        last_event_kind = last_event_kind,
+                        duckdb_path = %db_path.display(),
+                        duckdb_exists = db_path.exists(),
+                        schema_version = metrics.as_ref().and_then(|value| value.schema_version.clone()).unwrap_or_else(|| "unknown".to_string()),
+                        agg_trade_events = metrics.as_ref().map(|value| value.agg_trade_events).unwrap_or(0),
+                        last_agg_trade_event_time = metrics.as_ref().and_then(|value| value.last_agg_trade_event_time.clone()).unwrap_or_else(|| "n/a".to_string()),
+                        "heartbeat ping/pong"
+                    );
+                    daemon.last_heartbeat_log = Instant::now();
+                }
+            }
+        });
+
+        let shutdown_signal = async move {
+            while !shutdown.load(Ordering::Relaxed) {
+                tokio::time::sleep(Duration::from_millis(250)).await;
+            }
+        };
+
+        let result = axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown_signal)
+            .await;
+        let _ = supervisor.await;
+        info!(service = "trading-engine", "serve loop completed");
+        result.map_err(|error| -> Box<dyn std::error::Error> { Box::new(error) })
+    })
+}
+
+async fn trading_engine_status_handler(
+    State(state): State<TradingEngineServerState>,
+) -> Result<String, axum::http::StatusCode> {
+    let daemon = state
+        .daemon
+        .lock()
+        .map_err(|_| axum::http::StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(render_trading_engine_status(&daemon))
+}
+
+async fn trading_engine_health_handler(
+    State(state): State<TradingEngineServerState>,
+) -> Result<Json<TradingEngineHealthResponse>, axum::http::StatusCode> {
+    let daemon = state
+        .daemon
+        .lock()
+        .map_err(|_| axum::http::StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(Json(TradingEngineHealthResponse {
+        mode: daemon.app.mode.as_str().to_string(),
+        state: "running".to_string(),
+        heartbeat_age_sec: 0,
+        portfolio_status: prompt_status_from_store(&daemon.app.portfolio_store),
+        positions: daemon
+            .app
+            .portfolio_store
+            .snapshot
+            .positions
+            .values()
+            .filter(|position| !position.is_flat())
+            .count(),
+        open_order_groups: daemon.app.portfolio_store.snapshot.open_orders.len(),
+        last_event_kind: daemon
+            .app
+            .event_log
+            .records
+            .last()
+            .map(|record| record.kind.clone()),
+    }))
+}
+
+async fn trading_engine_stop_handler(
+    State(state): State<TradingEngineServerState>,
+) -> impl IntoResponse {
+    state.shutdown.store(true, Ordering::Relaxed);
+    Json(json!({ "status": "stopping" }))
+}
+
+async fn trading_engine_refresh_handler(
+    State(state): State<TradingEngineServerState>,
+) -> Result<Json<TradingEngineCommandResponse>, (axum::http::StatusCode, Json<serde_json::Value>)>
+{
+    execute_trading_engine_command(state, AppCommand::RefreshAuthoritativeState).await
+}
+
+async fn trading_engine_close_all_handler(
+    State(state): State<TradingEngineServerState>,
+) -> Result<Json<TradingEngineCommandResponse>, (axum::http::StatusCode, Json<serde_json::Value>)>
+{
+    execute_trading_engine_command(
+        state,
+        AppCommand::Execution(ExecutionCommand::CloseAll {
+            source: CommandSource::User,
+        }),
+    )
+    .await
+}
+
+async fn trading_engine_close_symbol_handler(
+    State(state): State<TradingEngineServerState>,
+    Json(request): Json<CloseSymbolRequest>,
+) -> Result<Json<TradingEngineCommandResponse>, (axum::http::StatusCode, Json<serde_json::Value>)>
+{
+    execute_trading_engine_command(
+        state,
+        AppCommand::Execution(ExecutionCommand::CloseSymbol {
+            instrument: Instrument::new(normalize_instrument_symbol(&request.instrument)),
+            source: CommandSource::User,
+        }),
+    )
+    .await
+}
+
+async fn trading_engine_set_target_exposure_handler(
+    State(state): State<TradingEngineServerState>,
+    Json(request): Json<SetTargetExposureRequest>,
+) -> Result<Json<TradingEngineCommandResponse>, (axum::http::StatusCode, Json<serde_json::Value>)>
+{
+    let target = Exposure::new(request.target).ok_or_else(|| {
+        (
+            axum::http::StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "target must be between -1.0 and 1.0" })),
+        )
+    })?;
+    let order_type = parse_order_type(request.order_type.as_deref(), request.limit_price).ok_or_else(
+        || {
+            (
+                axum::http::StatusCode::BAD_REQUEST,
+                Json(json!({
+                    "error": "order_type must be market or limit; limit orders require limit_price"
+                })),
+            )
+        },
+    )?;
+    execute_trading_engine_command(
+        state,
+        AppCommand::Execution(ExecutionCommand::SetTargetExposure {
+            instrument: Instrument::new(normalize_instrument_symbol(&request.instrument)),
+            target,
+            order_type,
+            source: CommandSource::User,
+        }),
+    )
+    .await
+}
+
+async fn execute_trading_engine_command(
+    state: TradingEngineServerState,
+    command: AppCommand,
+) -> Result<Json<TradingEngineCommandResponse>, (axum::http::StatusCode, Json<serde_json::Value>)>
+{
+    tokio::task::spawn_blocking(move || {
+        let mut daemon = state.daemon.lock().map_err(|_| {
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "failed to lock trading-engine daemon state" })),
+            )
+        })?;
+        let rendered_command = command.clone();
+        let daemon_ref = &mut *daemon;
+        daemon_ref
+            .runtime
+            .run(&mut daemon_ref.app, command)
+            .map_err(|error| {
+                (
+                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({ "error": error.to_string() })),
+                )
+            })?;
+        let rendered = render_command_output(
+            &rendered_command,
+            &daemon_ref.app.portfolio_store,
+            &daemon_ref.app.price_store,
+            &daemon_ref.app.event_log,
+            &daemon_ref.app.strategy_store,
+            daemon_ref.app.mode,
+        );
+        Ok(Json(TradingEngineCommandResponse {
+            status: "ok".to_string(),
+            rendered,
+            mode: daemon_ref.app.mode.as_str().to_string(),
+            last_event_kind: daemon_ref
+                .app
+                .event_log
+                .records
+                .last()
+                .map(|record| record.kind.clone()),
+        }))
+    })
+    .await
+    .map_err(|error| {
+        (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": error.to_string() })),
+        )
+    })?
+}
+
+fn parse_order_type(order_type: Option<&str>, limit_price: Option<f64>) -> Option<OrderType> {
+    match order_type.unwrap_or("market") {
+        "market" => Some(OrderType::Market),
+        "limit" => limit_price.map(|price| OrderType::Limit { price }),
+        _ => None,
+    }
+}
+
+fn render_trading_engine_status(daemon: &TradingEngineDaemon) -> String {
+    let positions = daemon
+        .app
+        .portfolio_store
+        .snapshot
+        .positions
+        .values()
+        .filter(|position| !position.is_flat())
+        .count();
+    let open_order_groups = daemon.app.portfolio_store.snapshot.open_orders.len();
+    let last_event_kind = daemon
+        .app
+        .event_log
+        .records
+        .last()
+        .map(|record| record.kind.clone())
+        .unwrap_or_else(|| "none".to_string());
+
+    [
+        "trading-engine status".to_string(),
+        format!("mode={}", daemon.app.mode.as_str()),
+        "state=running".to_string(),
+        "heartbeat_age_sec=0".to_string(),
+        format!(
+            "portfolio_status={}",
+            prompt_status_from_store(&daemon.app.portfolio_store)
+        ),
+        format!("positions={positions}"),
+        format!("open_order_groups={open_order_groups}"),
+        format!(
+            "strategy_watches={}",
+            daemon.app.strategy_store.active_watches(daemon.app.mode).len()
+        ),
+        format!("event_count={}", daemon.app.event_log.records.len()),
+        format!("last_event_kind={last_event_kind}"),
+        format!("base_dir={}", daemon.base_dir),
+        format!("binary_version={}", env!("CARGO_PKG_VERSION")),
+    ]
+    .join("\n")
+}
+
+fn configure_runtime(
+    app: &mut TradingBootstrap,
+    mode: BinanceMode,
+    base_dir: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if app.mode != mode {
+        app.switch_mode(mode)?;
+    }
+    app.recorder_coordination = RecorderCoordination::new(base_dir.to_string());
+    Ok(())
+}
+
+fn run_interactive(
+    app: &mut TradingBootstrap,
+    runtime: &mut AppRuntime,
+    base_dir: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let heartbeat_stop = Arc::new(AtomicBool::new(false));
+    let heartbeat_handle = spawn_trading_engine_heartbeat(
+        app.mode,
+        RecorderCoordination::new(base_dir).db_path(app.mode),
+        heartbeat_stop.clone(),
+    );
+    let result = run_shell(app, runtime);
+    heartbeat_stop.store(true, Ordering::Relaxed);
+    if let Err(error) = heartbeat_handle.join() {
+        error!(service = "trading-engine", error = ?error, "heartbeat thread join failed");
+    }
+    result
+}
+
+fn parse_runtime_args(args: &[String]) -> Result<(BinanceMode, String), Box<dyn std::error::Error>> {
+    let mut mode = BinanceMode::Demo;
+    let mut base_dir = "var".to_string();
+    let mut index = 0usize;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--mode" => {
+                let value = args.get(index + 1).ok_or("missing value for --mode")?;
+                mode = match value.as_str() {
+                    "demo" => BinanceMode::Demo,
+                    "real" => BinanceMode::Real,
+                    _ => return Err(format!("unsupported mode: {value}").into()),
+                };
+                index += 2;
+            }
+            "--base-dir" => {
+                let value = args.get(index + 1).ok_or("missing value for --base-dir")?;
+                base_dir = value.clone();
+                index += 2;
+            }
+            other => return Err(format!("unsupported arg for run: {other}").into()),
+        }
+    }
+    Ok((mode, base_dir))
+}
+
+fn parse_serve_args(args: &[String]) -> Result<TradingEngineServeConfig, Box<dyn std::error::Error>>
+{
+    let mut mode = BinanceMode::Demo;
+    let mut base_dir = "var".to_string();
+    let mut listen_addr = DEFAULT_TRADING_ENGINE_SERVER_ADDR.to_string();
+    let mut index = 0usize;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--mode" => {
+                let value = args.get(index + 1).ok_or("missing value for --mode")?;
+                mode = match value.as_str() {
+                    "demo" => BinanceMode::Demo,
+                    "real" => BinanceMode::Real,
+                    _ => return Err(format!("unsupported mode: {value}").into()),
+                };
+                index += 2;
+            }
+            "--base-dir" => {
+                let value = args.get(index + 1).ok_or("missing value for --base-dir")?;
+                base_dir = value.clone();
+                index += 2;
+            }
+            "--listen" => {
+                listen_addr = args
+                    .get(index + 1)
+                    .ok_or("missing value for --listen")?
+                    .clone();
+                index += 2;
+            }
+            other => return Err(format!("unsupported arg for serve: {other}").into()),
+        }
+    }
+    Ok(TradingEngineServeConfig {
+        mode,
+        base_dir,
+        listen_addr,
+    })
+}
+
+fn parse_server_addr(args: &[String]) -> Result<String, Box<dyn std::error::Error>> {
+    let mut listen_addr = DEFAULT_TRADING_ENGINE_SERVER_ADDR.to_string();
+    let mut index = 0usize;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--listen" => {
+                listen_addr = args
+                    .get(index + 1)
+                    .ok_or("missing value for --listen")?
+                    .clone();
+                index += 2;
+            }
+            other => return Err(format!("unsupported arg: {other}").into()),
+        }
+    }
+    Ok(listen_addr)
+}
+
+fn request_trading_engine_server(
+    method: &str,
+    path: &str,
+    listen_addr: String,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let client = Client::builder().build()?;
+    let url = format!("http://{listen_addr}{path}");
+    let response = match method {
+        "GET" => client.get(url).send()?,
+        "POST" => client.post(url).send()?,
+        other => return Err(format!("unsupported method: {other}").into()),
+    }
+    .error_for_status()?;
+    Ok(response.text()?)
+}
+
+fn spawn_trading_engine_heartbeat(
+    mode: BinanceMode,
+    db_path: std::path::PathBuf,
+    stop_flag: Arc<AtomicBool>,
+) -> std::thread::JoinHandle<()> {
+    thread::spawn(move || {
+        while !stop_flag.load(Ordering::Relaxed) {
+            let metrics = metrics_for_path(&db_path).ok();
+            info!(
+                service = "trading-engine",
+                kind = "heartbeat",
+                mode = mode.as_str(),
+                ping_at = %Utc::now().to_rfc3339(),
+                pong = "alive",
+                heartbeat_age_sec = 0,
+                duckdb_path = %db_path.display(),
+                duckdb_exists = db_path.exists(),
+                schema_version = metrics.as_ref().and_then(|value| value.schema_version.clone()).unwrap_or_else(|| "unknown".to_string()),
+                agg_trade_events = metrics.as_ref().map(|value| value.agg_trade_events).unwrap_or(0),
+                last_agg_trade_event_time = metrics.as_ref().and_then(|value| value.last_agg_trade_event_time.clone()).unwrap_or_else(|| "n/a".to_string()),
+                "heartbeat ping/pong"
+            );
+            thread::sleep(Duration::from_secs(5));
+        }
+    })
 }

--- a/src/market_data/binance_kline_backfill.rs
+++ b/src/market_data/binance_kline_backfill.rs
@@ -1,0 +1,271 @@
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use std::time::Duration as StdDuration;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Duration, NaiveDate, NaiveDateTime, TimeZone, Timelike, Utc};
+use reqwest::blocking::Client;
+use serde_json::Value;
+use tracing::info;
+
+use crate::app::bootstrap::BinanceMode;
+use crate::storage::postgres_market_data::{
+    connect as connect_postgres, init_schema as init_postgres_schema, insert_kline,
+    latest_shared_kline_open_time_ms, PostgresKlineRecord,
+};
+
+pub const DEFAULT_BINANCE_BACKFILL_SYMBOLS: &[&str] = &["BTCUSDT", "SOLUSDT", "XRPUSDT", "ETHUSDT"];
+pub const DEFAULT_BINANCE_BACKFILL_PRODUCT: &str = "um";
+pub const DEFAULT_BINANCE_BACKFILL_INTERVAL: &str = "1m";
+pub const DEFAULT_BINANCE_BACKFILL_START_DATE: &str = "2023-03-15";
+pub const DEFAULT_BINANCE_BACKFILL_POLL_SECONDS: u64 = 30;
+const DEFAULT_LIMIT: usize = 1_500;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BinanceKlineBackfillConfig {
+    pub postgres_url: String,
+    pub symbols: Vec<String>,
+    pub mode: BinanceMode,
+    pub product: String,
+    pub interval: String,
+    pub fallback_start_ms: i64,
+    pub continuous: bool,
+    pub poll_seconds: u64,
+}
+
+pub fn run_binance_kline_backfill(
+    config: &BinanceKlineBackfillConfig,
+    stop_flag: Option<Arc<AtomicBool>>,
+) -> Result<()> {
+    let mut client = connect_postgres(&config.postgres_url)?;
+    let _ = init_postgres_schema(&mut client, &config.postgres_url)?;
+    let http = Client::builder()
+        .build()
+        .context("failed to build HTTP client")?;
+
+    info!(
+        service = "postgres-kline-backfill",
+        mode = config.mode.as_str(),
+        product = config.product,
+        interval = config.interval,
+        symbols = %config.symbols.join(","),
+        continuous = config.continuous,
+        poll_seconds = config.poll_seconds,
+        "postgres kline backfill starting"
+    );
+
+    loop {
+        if stop_flag
+            .as_ref()
+            .is_some_and(|flag| flag.load(Ordering::Relaxed))
+        {
+            break;
+        }
+
+        let now_minute = current_closed_minute_open_ms();
+        let mut cycle_rows = 0u64;
+        for symbol in &config.symbols {
+            let inserted = backfill_symbol(
+                &http,
+                &mut client,
+                config.mode,
+                &config.product,
+                &config.interval,
+                symbol,
+                config.fallback_start_ms,
+                now_minute,
+            )?;
+            cycle_rows += inserted;
+            info!(
+                service = "postgres-kline-backfill",
+                mode = config.mode.as_str(),
+                symbol = symbol,
+                inserted_rows = inserted,
+                "symbol backfill cycle completed"
+            );
+        }
+
+        info!(
+            service = "postgres-kline-backfill",
+            mode = config.mode.as_str(),
+            inserted_rows = cycle_rows,
+            "postgres kline backfill cycle completed"
+        );
+
+        if !config.continuous {
+            break;
+        }
+        std::thread::sleep(StdDuration::from_secs(config.poll_seconds));
+    }
+
+    info!(
+        service = "postgres-kline-backfill",
+        mode = config.mode.as_str(),
+        "postgres kline backfill stopped"
+    );
+    Ok(())
+}
+
+pub fn parse_start_time(raw: &str) -> Result<i64> {
+    if let Ok(datetime) = DateTime::parse_from_rfc3339(raw) {
+        return Ok(datetime.timestamp_millis());
+    }
+    if let Ok(date) = NaiveDate::parse_from_str(raw, "%Y-%m-%d") {
+        let datetime = date
+            .and_hms_opt(0, 0, 0)
+            .context("invalid fallback start date")?;
+        return Ok(Utc.from_utc_datetime(&datetime).timestamp_millis());
+    }
+    if let Ok(datetime) = NaiveDateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S") {
+        return Ok(Utc.from_utc_datetime(&datetime).timestamp_millis());
+    }
+    anyhow::bail!("unsupported SANDBOX_QUANT_BACKFILL_FROM format: {raw}")
+}
+
+pub fn interval_millis(interval: &str) -> Result<i64> {
+    match interval {
+        "1m" => Ok(Duration::minutes(1).num_milliseconds()),
+        other => anyhow::bail!("unsupported interval: {other}"),
+    }
+}
+
+pub fn current_closed_minute_open_ms() -> i64 {
+    let now = Utc::now();
+    let closed = now
+        .with_second(0)
+        .and_then(|value| value.with_nanosecond(0))
+        .unwrap_or(now)
+        - Duration::minutes(1);
+    closed.timestamp_millis()
+}
+
+fn backfill_symbol(
+    http: &Client,
+    client: &mut postgres::Client,
+    mode: BinanceMode,
+    product: &str,
+    interval: &str,
+    symbol: &str,
+    fallback_start_ms: i64,
+    max_open_time_ms: i64,
+) -> Result<u64> {
+    let mut start_ms = latest_shared_kline_open_time_ms(client, product, symbol, interval)?
+        .unwrap_or(fallback_start_ms);
+    if start_ms < fallback_start_ms {
+        start_ms = fallback_start_ms;
+    } else {
+        start_ms += interval_millis(interval)?;
+    }
+
+    if start_ms > max_open_time_ms {
+        return Ok(0);
+    }
+
+    let mut inserted_rows = 0u64;
+    let interval_ms = interval_millis(interval)?;
+
+    while start_ms <= max_open_time_ms {
+        let url = format!(
+            "https://fapi.binance.com/fapi/v1/klines?symbol={symbol}&interval={interval}&startTime={start_ms}&limit={DEFAULT_LIMIT}"
+        );
+        let rows = http
+            .get(&url)
+            .send()
+            .with_context(|| format!("failed to fetch klines for {symbol}"))?
+            .error_for_status()
+            .with_context(|| format!("kline HTTP status error for {symbol}"))?
+            .json::<Vec<Vec<Value>>>()
+            .with_context(|| format!("failed to decode kline response for {symbol}"))?;
+
+        if rows.is_empty() {
+            break;
+        }
+
+        let mut last_open_time_ms = start_ms;
+        for row in rows {
+            let record = parse_kline_row(mode, product, symbol, interval, row)?;
+            last_open_time_ms = record.open_time_ms;
+            if record.open_time_ms > max_open_time_ms {
+                break;
+            }
+            insert_kline(client, &record)?;
+            inserted_rows += 1;
+        }
+
+        let next_start_ms = last_open_time_ms + interval_ms;
+        if next_start_ms <= start_ms {
+            break;
+        }
+        start_ms = next_start_ms;
+    }
+
+    Ok(inserted_rows)
+}
+
+fn parse_kline_row(
+    _mode: BinanceMode,
+    product: &str,
+    symbol: &str,
+    interval: &str,
+    row: Vec<Value>,
+) -> Result<PostgresKlineRecord> {
+    if row.len() < 11 {
+        anyhow::bail!("kline row too short for {symbol}");
+    }
+
+    let open_time_ms = value_as_i64(&row[0])?;
+    let open = value_as_f64(&row[1])?;
+    let high = value_as_f64(&row[2])?;
+    let low = value_as_f64(&row[3])?;
+    let close = value_as_f64(&row[4])?;
+    let volume = value_as_f64(&row[5])?;
+    let close_time_ms = value_as_i64(&row[6])?;
+    let quote_volume = value_as_f64(&row[7])?;
+    let trade_count = value_as_i64(&row[8])?;
+    let taker_buy_base_volume = value_as_optional_f64(&row[9])?;
+    let taker_buy_quote_volume = value_as_optional_f64(&row[10])?;
+
+    Ok(PostgresKlineRecord {
+        product: product.to_string(),
+        symbol: symbol.to_string(),
+        interval_name: interval.to_string(),
+        open_time_ms,
+        close_time_ms,
+        open,
+        high,
+        low,
+        close,
+        volume,
+        quote_volume,
+        trade_count,
+        taker_buy_base_volume,
+        taker_buy_quote_volume,
+        raw_payload: serde_json::to_string(&row).context("failed to encode raw kline payload")?,
+    })
+}
+
+fn value_as_i64(value: &Value) -> Result<i64> {
+    match value {
+        Value::Number(number) => number.as_i64().context("expected integer number"),
+        Value::String(text) => text.parse::<i64>().context("expected integer string"),
+        _ => anyhow::bail!("expected integer value"),
+    }
+}
+
+fn value_as_f64(value: &Value) -> Result<f64> {
+    match value {
+        Value::Number(number) => number.as_f64().context("expected float number"),
+        Value::String(text) => text.parse::<f64>().context("expected float string"),
+        _ => anyhow::bail!("expected float value"),
+    }
+}
+
+fn value_as_optional_f64(value: &Value) -> Result<Option<f64>> {
+    match value {
+        Value::Null => Ok(None),
+        Value::String(text) if text.is_empty() => Ok(None),
+        _ => value_as_f64(value).map(Some),
+    }
+}

--- a/src/market_data/mod.rs
+++ b/src/market_data/mod.rs
@@ -1,2 +1,3 @@
+pub mod binance_kline_backfill;
 pub mod price_store;
 pub mod service;

--- a/src/observability/logging.rs
+++ b/src/observability/logging.rs
@@ -1,0 +1,134 @@
+use std::fs::{create_dir_all, File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use tracing_subscriber::fmt::writer::{BoxMakeWriter, MakeWriter};
+use tracing_subscriber::EnvFilter;
+
+#[derive(Clone)]
+struct TeeMakeWriter {
+    file: Option<Arc<Mutex<File>>>,
+}
+
+struct TeeWriter {
+    file: Option<Arc<Mutex<File>>>,
+}
+
+impl<'a> MakeWriter<'a> for TeeMakeWriter {
+    type Writer = TeeWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        TeeWriter {
+            file: self.file.clone(),
+        }
+    }
+}
+
+impl Write for TeeWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut stderr = io::stderr().lock();
+        stderr.write_all(buf)?;
+        if let Some(file) = &self.file {
+            let mut file = file
+                .lock()
+                .map_err(|_| io::Error::other("failed to lock log file"))?;
+            file.write_all(buf)?;
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let mut stderr = io::stderr().lock();
+        stderr.flush()?;
+        if let Some(file) = &self.file {
+            let mut file = file
+                .lock()
+                .map_err(|_| io::Error::other("failed to lock log file"))?;
+            file.flush()?;
+        }
+        Ok(())
+    }
+}
+
+pub fn init_logging(service: &str, mode: Option<&str>) -> io::Result<()> {
+    let writer = build_writer(service, mode)?;
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("info,sandbox_quant=info,reqwest=warn,hyper=warn"));
+    let subscriber = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(writer)
+        .json()
+        .flatten_event(true)
+        .with_current_span(false)
+        .with_span_list(false)
+        .with_ansi(false)
+        .finish();
+
+    if tracing::subscriber::set_global_default(subscriber).is_ok() {
+        install_panic_hook(service, mode);
+    }
+    Ok(())
+}
+
+fn build_writer(service: &str, mode: Option<&str>) -> io::Result<BoxMakeWriter> {
+    let log_dir = std::env::var("SANDBOX_QUANT_LOG_DIR").unwrap_or_else(|_| "var/log".to_string());
+    let file = open_log_file(Path::new(&log_dir), service, mode)?;
+    Ok(BoxMakeWriter::new(TeeMakeWriter { file }))
+}
+
+fn open_log_file(
+    dir: &Path,
+    service: &str,
+    mode: Option<&str>,
+) -> io::Result<Option<Arc<Mutex<File>>>> {
+    create_dir_all(dir)?;
+    let mut filename = sanitize_component(service);
+    if let Some(mode) = mode.filter(|mode| !mode.trim().is_empty()) {
+        filename.push('-');
+        filename.push_str(&sanitize_component(mode));
+    }
+    filename.push_str(".jsonl");
+    let path: PathBuf = dir.join(filename);
+    let file = OpenOptions::new().create(true).append(true).open(path)?;
+    Ok(Some(Arc::new(Mutex::new(file))))
+}
+
+fn sanitize_component(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_') {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+fn install_panic_hook(service: &str, mode: Option<&str>) {
+    let service = service.to_string();
+    let mode = mode.map(str::to_string);
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic_info| {
+        let location = panic_info
+            .location()
+            .map(|location| format!("{}:{}", location.file(), location.line()))
+            .unwrap_or_else(|| "unknown".to_string());
+        let payload = panic_info
+            .payload()
+            .downcast_ref::<&str>()
+            .map(|value| value.to_string())
+            .or_else(|| panic_info.payload().downcast_ref::<String>().cloned())
+            .unwrap_or_else(|| "unknown panic payload".to_string());
+        tracing::error!(
+            service = service,
+            mode = mode.as_deref().unwrap_or("unknown"),
+            location = location,
+            panic = payload,
+            "process panicked"
+        );
+        previous(panic_info);
+    }));
+}

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -1,0 +1,1 @@
+pub mod logging;

--- a/src/record/coordination.rs
+++ b/src/record/coordination.rs
@@ -98,6 +98,11 @@ fn normalize_symbols(symbols: Vec<String>) -> Vec<String> {
 }
 
 fn atomic_write(path: PathBuf, bytes: &[u8]) -> Result<(), StorageError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| StorageError::WriteFailedWithContext {
+            message: error.to_string(),
+        })?;
+    }
     let tmp_path = path.with_extension("tmp");
     fs::write(&tmp_path, bytes).map_err(|error| StorageError::WriteFailedWithContext {
         message: error.to_string(),

--- a/src/recorder_app/runtime.rs
+++ b/src/recorder_app/runtime.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
+    mpsc::{self, RecvTimeoutError, Sender},
     Arc, Mutex,
 };
 use std::thread::JoinHandle;
@@ -13,6 +14,7 @@ use futures_util::StreamExt;
 use serde::Deserialize;
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::Message;
+use tracing::{error, warn};
 
 use crate::app::bootstrap::BinanceMode;
 use crate::dataset::query::{backtest_summary_for_path, metrics_for_path};
@@ -21,10 +23,10 @@ use crate::dataset::types::{BacktestDatasetSummary, RecorderMetrics};
 use crate::error::storage_error::StorageError;
 use crate::record::coordination::RecorderCoordination;
 use crate::storage::postgres_market_data::{
-    connect as connect_postgres, init_schema as init_postgres_schema, insert_agg_trade,
-    insert_book_ticker, insert_liquidation, mask_postgres_url, metrics_for_postgres_url,
-    postgres_url_from_env, CollectorStorageBackend, PostgresAggTradeRecord,
-    PostgresBookTickerRecord, PostgresLiquidationRecord,
+    connect as connect_postgres, ensure_recorder_schema_ready, insert_agg_trade, insert_book_ticker,
+    insert_liquidation, mask_postgres_url, metrics_for_postgres_url, postgres_url_from_env,
+    CollectorStorageBackend, PostgresAggTradeRecord, PostgresBookTickerRecord,
+    PostgresLiquidationRecord,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -58,6 +60,8 @@ pub struct RecorderStatus {
     pub manual_symbols: Vec<String>,
     pub strategy_symbols: Vec<String>,
     pub watched_symbols: Vec<String>,
+    pub reader_alive: bool,
+    pub writer_alive: bool,
     pub worker_alive: bool,
     pub heartbeat_age_sec: i64,
     pub last_error: Option<String>,
@@ -91,6 +95,8 @@ impl RecorderStatus {
             manual_symbols,
             strategy_symbols,
             watched_symbols,
+            reader_alive: true,
+            writer_alive: true,
             worker_alive: true,
             heartbeat_age_sec: 0,
             last_error: None,
@@ -106,6 +112,13 @@ struct WorkerSnapshot {
     last_error: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+enum PostgresWriteCommand {
+    Liquidation(PostgresLiquidationRecord),
+    BookTicker(PostgresBookTickerRecord),
+    AggTrade(PostgresAggTradeRecord),
+}
+
 impl WorkerSnapshot {
     fn new(metrics: RecorderMetrics) -> Self {
         Self {
@@ -119,7 +132,8 @@ impl WorkerSnapshot {
 struct ModeWorker {
     stop_flag: Arc<AtomicBool>,
     snapshot: Arc<Mutex<WorkerSnapshot>>,
-    pub(crate) handle: JoinHandle<()>,
+    pub(crate) reader_handle: JoinHandle<()>,
+    pub(crate) writer_handle: Option<JoinHandle<()>>,
 }
 
 pub struct MarketDataRecorder {
@@ -196,7 +210,7 @@ impl MarketDataRecorder {
             init_schema_for_path(&db_path)?;
         } else if let Some(url) = self.postgres_url.as_deref() {
             let mut client = connect_postgres(url)?;
-            let _ = init_postgres_schema(&mut client, url)?;
+            ensure_recorder_schema_ready(&mut client, url)?;
         }
         let manual_symbols = normalize_symbols(manual_symbols);
         let strategy_symbols = normalize_symbols(strategy_symbols);
@@ -235,8 +249,12 @@ impl MarketDataRecorder {
             )
         });
         if let Some(worker) = self.workers.get(&mode) {
-            let worker_alive = !worker.handle.is_finished();
-            status.worker_alive = worker_alive;
+            status.reader_alive = !worker.reader_handle.is_finished();
+            status.writer_alive = worker
+                .writer_handle
+                .as_ref()
+                .is_none_or(|handle| !handle.is_finished());
+            status.worker_alive = status.reader_alive && status.writer_alive;
             if let Ok(snapshot) = worker.snapshot.lock() {
                 status.updated_at = snapshot.updated_at;
                 status.heartbeat_age_sec = (Utc::now() - snapshot.updated_at).num_seconds();
@@ -244,6 +262,8 @@ impl MarketDataRecorder {
                 status.last_error = snapshot.last_error.clone();
             }
         } else {
+            status.reader_alive = false;
+            status.writer_alive = false;
             status.worker_alive = false;
             status.heartbeat_age_sec = (Utc::now() - status.updated_at).num_seconds();
             status.metrics = self.load_metrics(&status.db_path).unwrap_or_default();
@@ -326,6 +346,8 @@ impl MarketDataRecorder {
 
         existing.state = RecorderState::Stopped;
         existing.updated_at = Utc::now();
+        existing.reader_alive = false;
+        existing.writer_alive = false;
         existing.worker_alive = false;
         Ok(existing.clone())
     }
@@ -343,7 +365,7 @@ impl MarketDataRecorder {
     pub fn worker_alive(&self, mode: BinanceMode) -> bool {
         self.workers
             .get(&mode)
-            .is_some_and(|worker| !worker.handle.is_finished())
+            .is_some_and(|worker| !worker.reader_handle.is_finished())
     }
 
     pub fn metrics_for_path(db_path: &Path) -> Result<RecorderMetrics, StorageError> {
@@ -389,12 +411,25 @@ impl MarketDataRecorder {
         let snapshot = Arc::new(Mutex::new(WorkerSnapshot::new(initial_metrics)));
         let worker_snapshot = snapshot.clone();
         let storage_backend = self.storage_backend;
-        let postgres_url = self.postgres_url.clone();
-        let handle = std::thread::Builder::new()
+        let (postgres_writer, writer_handle) = initialize_postgres_writer(
+            storage_backend,
+            self.postgres_url.as_deref(),
+            worker_stop_flag.clone(),
+            worker_snapshot.clone(),
+        )?;
+        let reader_handle = std::thread::Builder::new()
             .name(format!("market-recorder-{}", mode.as_str()))
             .spawn(move || {
                 let _ = rustls::crypto::ring::default_provider().install_default();
-                let runtime = tokio::runtime::Builder::new_current_thread()
+                let duck_connection = match initialize_duckdb_storage(&db_path, storage_backend) {
+                    Ok(storage) => storage,
+                    Err(error) => {
+                        record_worker_error(&worker_snapshot, error.to_string());
+                        return;
+                    }
+                };
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .worker_threads(1)
                     .enable_all()
                     .build();
                 let Ok(runtime) = runtime else {
@@ -404,12 +439,11 @@ impl MarketDataRecorder {
                     );
                     return;
                 };
-                runtime.block_on(async move {
+                runtime.block_on(async {
                     run_market_data_worker(
                         mode,
-                        db_path,
-                        storage_backend,
-                        postgres_url,
+                        duck_connection.as_ref(),
+                        postgres_writer.as_ref(),
                         watched_symbols,
                         worker_stop_flag,
                         worker_snapshot,
@@ -425,7 +459,8 @@ impl MarketDataRecorder {
             ModeWorker {
                 stop_flag,
                 snapshot,
-                handle,
+                reader_handle,
+                writer_handle,
             },
         );
         Ok(())
@@ -469,53 +504,85 @@ impl Drop for MarketDataRecorder {
     }
 }
 
+fn initialize_duckdb_storage(
+    db_path: &Path,
+    storage_backend: CollectorStorageBackend,
+) -> Result<Option<Connection>, StorageError> {
+    if storage_backend != CollectorStorageBackend::DuckDb {
+        return Ok(None);
+    }
+    Connection::open(db_path)
+        .map(Some)
+        .map_err(|_| StorageError::WriteFailedWithContext {
+            message: format!("failed to open duckdb at {}", db_path.display()),
+        })
+}
+
+fn initialize_postgres_writer(
+    storage_backend: CollectorStorageBackend,
+    postgres_url: Option<&str>,
+    stop_flag: Arc<AtomicBool>,
+    snapshot: Arc<Mutex<WorkerSnapshot>>,
+) -> Result<(Option<Sender<PostgresWriteCommand>>, Option<JoinHandle<()>>), StorageError> {
+    if storage_backend != CollectorStorageBackend::Postgres {
+        return Ok((None, None));
+    }
+    let url = postgres_url.ok_or_else(|| StorageError::WriteFailedWithContext {
+        message: "postgres recorder backend missing URL".to_string(),
+    })?;
+    let mut client = connect_postgres(url)?;
+    ensure_recorder_schema_ready(&mut client, url)?;
+    let (sender, receiver) = mpsc::channel::<PostgresWriteCommand>();
+    let handle = std::thread::Builder::new()
+        .name("market-recorder-postgres-writer".to_string())
+        .spawn(move || run_postgres_writer_loop(client, receiver, stop_flag, snapshot))
+        .map_err(|error| StorageError::WriteFailedWithContext {
+            message: error.to_string(),
+        })?;
+    Ok((Some(sender), Some(handle)))
+}
+
+fn run_postgres_writer_loop(
+    mut client: postgres::Client,
+    receiver: mpsc::Receiver<PostgresWriteCommand>,
+    stop_flag: Arc<AtomicBool>,
+    snapshot: Arc<Mutex<WorkerSnapshot>>,
+) {
+    loop {
+        match receiver.recv_timeout(Duration::from_millis(250)) {
+            Ok(PostgresWriteCommand::Liquidation(record)) => {
+                if let Err(error) = insert_liquidation(&mut client, &record) {
+                    record_worker_error(&snapshot, error.to_string());
+                    break;
+                }
+            }
+            Ok(PostgresWriteCommand::BookTicker(record)) => {
+                if let Err(error) = insert_book_ticker(&mut client, &record) {
+                    record_worker_error(&snapshot, error.to_string());
+                    break;
+                }
+            }
+            Ok(PostgresWriteCommand::AggTrade(record)) => {
+                if let Err(error) = insert_agg_trade(&mut client, &record) {
+                    record_worker_error(&snapshot, error.to_string());
+                    break;
+                }
+            }
+            Err(RecvTimeoutError::Timeout) if stop_flag.load(Ordering::Relaxed) => break,
+            Err(RecvTimeoutError::Timeout) => continue,
+            Err(RecvTimeoutError::Disconnected) => break,
+        }
+    }
+}
+
 async fn run_market_data_worker(
     mode: BinanceMode,
-    db_path: PathBuf,
-    storage_backend: CollectorStorageBackend,
-    postgres_url: Option<String>,
+    duck_connection: Option<&Connection>,
+    postgres_writer: Option<&Sender<PostgresWriteCommand>>,
     watched_symbols: Vec<String>,
     stop_flag: Arc<AtomicBool>,
     snapshot: Arc<Mutex<WorkerSnapshot>>,
 ) {
-    let duck_connection = if storage_backend == CollectorStorageBackend::DuckDb {
-        match Connection::open(&db_path) {
-            Ok(connection) => Some(connection),
-            Err(_) => {
-                record_worker_error(
-                    &snapshot,
-                    format!("failed to open duckdb at {}", db_path.display()),
-                );
-                return;
-            }
-        }
-    } else {
-        None
-    };
-    let mut postgres_client = if storage_backend == CollectorStorageBackend::Postgres {
-        let Some(url) = postgres_url.as_deref() else {
-            record_worker_error(
-                &snapshot,
-                "postgres recorder backend missing URL".to_string(),
-            );
-            return;
-        };
-        match connect_postgres(url) {
-            Ok(mut client) => {
-                if let Err(error) = init_postgres_schema(&mut client, url) {
-                    record_worker_error(&snapshot, error.to_string());
-                    return;
-                }
-                Some(client)
-            }
-            Err(error) => {
-                record_worker_error(&snapshot, error.to_string());
-                return;
-            }
-        }
-    } else {
-        None
-    };
     let mut agg_trade_bar_seconds = BTreeMap::new();
 
     loop {
@@ -532,11 +599,7 @@ async fn run_market_data_worker(
             Ok((stream, _)) => stream,
             Err(error) => {
                 record_worker_error(&snapshot, format!("forceOrder connect failed: {error}"));
-                eprintln!(
-                    "market recorder: failed to connect forceOrder stream mode={} error={}",
-                    mode.as_str(),
-                    error
-                );
+                warn!(service = "recorder", error = %error, "failed to connect forceOrder stream");
                 tokio::time::sleep(Duration::from_secs(2)).await;
                 continue;
             }
@@ -550,12 +613,7 @@ async fn run_market_data_worker(
                         &snapshot,
                         format!("symbol stream connect failed: {error}"),
                     );
-                    eprintln!(
-                        "market recorder: failed to connect symbol streams mode={} symbols={} error={}",
-                        mode.as_str(),
-                        watched_symbols.join(","),
-                        error
-                    );
+                    warn!(service = "recorder", symbols = %watched_symbols.join(","), error = %error, "failed to connect symbol streams");
                     None
                 }
             },
@@ -576,37 +634,26 @@ async fn run_market_data_worker(
                     match message {
                         Some(Ok(message)) => {
                             if let Err(error) = handle_force_order_message(
-                                duck_connection.as_ref(),
-                                postgres_client.as_mut(),
+                                duck_connection,
+                                postgres_writer,
                                 mode,
                                 &mut liquidation_seq,
                                 &snapshot,
                                 message
                             ) {
                                 record_worker_error(&snapshot, error.to_string());
-                                eprintln!(
-                                    "market recorder: forceOrder stream handling failed mode={} error={}",
-                                    mode.as_str(),
-                                    error
-                                );
+                                error!(service = "recorder", error = %error, "forceOrder stream handling failed");
                                 break;
                             }
                         }
                         Some(Err(error)) => {
                             record_worker_error(&snapshot, format!("forceOrder stream disconnected: {error}"));
-                            eprintln!(
-                                "market recorder: forceOrder stream disconnected mode={} error={}",
-                                mode.as_str(),
-                                error
-                            );
+                            warn!(service = "recorder", error = %error, "forceOrder stream disconnected");
                             break
                         }
                         None => {
                             record_worker_error(&snapshot, "forceOrder stream disconnected: eof".to_string());
-                            eprintln!(
-                                "market recorder: forceOrder stream disconnected mode={} error=eof",
-                                mode.as_str()
-                            );
+                            warn!(service = "recorder", "forceOrder stream disconnected: eof");
                             break
                         }
                     }
@@ -615,8 +662,8 @@ async fn run_market_data_worker(
                     match message {
                         Some(Ok(message)) => {
                             if let Err(error) = handle_symbol_message(
-                                duck_connection.as_ref(),
-                                postgres_client.as_mut(),
+                                duck_connection,
+                                postgres_writer,
                                 mode,
                                 &mut ticker_seq,
                                 &mut trade_seq,
@@ -625,31 +672,18 @@ async fn run_market_data_worker(
                                 message,
                             ) {
                                 record_worker_error(&snapshot, error.to_string());
-                                eprintln!(
-                                    "market recorder: symbol stream handling failed mode={} error={}",
-                                    mode.as_str(),
-                                    error
-                                );
+                                error!(service = "recorder", error = %error, "symbol stream handling failed");
                                 break;
                             }
                         }
                         Some(Err(error)) => {
                             record_worker_error(&snapshot, format!("symbol stream disconnected: {error}"));
-                            eprintln!(
-                                "market recorder: symbol stream disconnected mode={} symbols={} error={}",
-                                mode.as_str(),
-                                watched_symbols.join(","),
-                                error
-                            );
+                            warn!(service = "recorder", symbols = %watched_symbols.join(","), error = %error, "symbol stream disconnected");
                             break
                         }
                         None => {
                             record_worker_error(&snapshot, "symbol stream disconnected: eof".to_string());
-                            eprintln!(
-                                "market recorder: symbol stream disconnected mode={} symbols={} error=eof",
-                                mode.as_str(),
-                                watched_symbols.join(",")
-                            );
+                            warn!(service = "recorder", symbols = %watched_symbols.join(","), "symbol stream disconnected: eof");
                             break
                         }
                     }
@@ -679,7 +713,7 @@ async fn next_symbol_message(
 
 fn handle_force_order_message(
     duck_connection: Option<&Connection>,
-    postgres_client: Option<&mut postgres::Client>,
+    postgres_writer: Option<&Sender<PostgresWriteCommand>>,
     mode: BinanceMode,
     sequence: &mut i64,
     snapshot: &Arc<Mutex<WorkerSnapshot>>,
@@ -730,22 +764,24 @@ fn handle_force_order_message(
             .map_err(|error| StorageError::WriteFailedWithContext {
                 message: error.to_string(),
             })?;
-    } else if let Some(client) = postgres_client {
-        insert_liquidation(
-            client,
-            &PostgresLiquidationRecord {
-                mode: mode.as_str().to_string(),
-                product: "um".to_string(),
-                symbol: symbol.clone(),
-                event_time_ms: parsed.event_time,
-                receive_time_ms,
-                force_side: side,
-                price: order.price,
-                qty: order.qty,
-                notional: order.price * order.qty,
-                raw_payload: payload,
-            },
-        )?;
+    } else if let Some(sender) = postgres_writer {
+        sender
+            .send(PostgresWriteCommand::Liquidation(
+                PostgresLiquidationRecord {
+                    product: "um".to_string(),
+                    symbol: symbol.clone(),
+                    event_time_ms: parsed.event_time,
+                    receive_time_ms,
+                    force_side: side,
+                    price: order.price,
+                    qty: order.qty,
+                    notional: order.price * order.qty,
+                    raw_payload: payload,
+                },
+            ))
+            .map_err(|error| StorageError::WriteFailedWithContext {
+                message: format!("postgres liquidation writer disconnected: {error}"),
+            })?;
     } else {
         return Err(StorageError::WriteFailedWithContext {
             message: "no recorder storage backend available".to_string(),
@@ -757,7 +793,7 @@ fn handle_force_order_message(
 
 fn handle_symbol_message(
     duck_connection: Option<&Connection>,
-    postgres_client: Option<&mut postgres::Client>,
+    postgres_writer: Option<&Sender<PostgresWriteCommand>>,
     mode: BinanceMode,
     ticker_sequence: &mut i64,
     trade_sequence: &mut i64,
@@ -824,11 +860,9 @@ fn handle_symbol_message(
                 .map_err(|error| StorageError::WriteFailedWithContext {
                     message: error.to_string(),
                 })?;
-        } else if let Some(client) = postgres_client {
-            insert_book_ticker(
-                client,
-                &PostgresBookTickerRecord {
-                    mode: mode.as_str().to_string(),
+        } else if let Some(sender) = postgres_writer {
+            sender
+                .send(PostgresWriteCommand::BookTicker(PostgresBookTickerRecord {
                     symbol: symbol.clone(),
                     event_time_ms: event_time,
                     receive_time_ms,
@@ -836,8 +870,10 @@ fn handle_symbol_message(
                     bid_qty,
                     ask,
                     ask_qty,
-                },
-            )?;
+                }))
+                .map_err(|error| StorageError::WriteFailedWithContext {
+                    message: format!("postgres book_ticker writer disconnected: {error}"),
+                })?;
         } else {
             return Err(StorageError::WriteFailedWithContext {
                 message: "no recorder storage backend available".to_string(),
@@ -883,19 +919,19 @@ fn handle_symbol_message(
                 .map_err(|error| StorageError::WriteFailedWithContext {
                     message: error.to_string(),
                 })?;
-        } else if let Some(client) = postgres_client {
-            insert_agg_trade(
-                client,
-                &PostgresAggTradeRecord {
-                    mode: mode.as_str().to_string(),
+        } else if let Some(sender) = postgres_writer {
+            sender
+                .send(PostgresWriteCommand::AggTrade(PostgresAggTradeRecord {
                     symbol: symbol.clone(),
                     event_time_ms: event_time,
                     receive_time_ms,
                     price,
                     qty,
                     is_buyer_maker,
-                },
-            )?;
+                }))
+                .map_err(|error| StorageError::WriteFailedWithContext {
+                    message: format!("postgres agg_trade writer disconnected: {error}"),
+                })?;
         } else {
             return Err(StorageError::WriteFailedWithContext {
                 message: "no recorder storage backend available".to_string(),
@@ -1148,4 +1184,95 @@ fn timestamp_string(event_time_ms: i64) -> Option<String> {
                 .format("%Y-%m-%d %H:%M:%S%.3f")
                 .to_string()
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dataset::types::RecorderMetrics;
+
+    #[test]
+    fn handle_force_order_message_persists_liquidation_and_updates_metrics() {
+        let connection = Connection::open_in_memory().expect("open duckdb");
+        connection
+            .execute_batch(
+                "CREATE TABLE raw_liquidation_events (
+                    event_id BIGINT,
+                    mode TEXT,
+                    symbol TEXT,
+                    event_time TIMESTAMP,
+                    receive_time TIMESTAMP,
+                    force_side TEXT,
+                    price DOUBLE,
+                    qty DOUBLE,
+                    notional DOUBLE,
+                    raw_payload TEXT
+                );",
+            )
+            .expect("create raw_liquidation_events");
+        let snapshot = Arc::new(Mutex::new(WorkerSnapshot::new(RecorderMetrics::default())));
+        let payload = serde_json::json!({
+            "E": 1_710_000_000_123_i64,
+            "o": {
+                "s": "BTCUSDT",
+                "S": "SELL",
+                "p": "68250.5",
+                "q": "0.125"
+            }
+        })
+        .to_string();
+        let mut sequence = 0i64;
+
+        handle_force_order_message(
+            Some(&connection),
+            None,
+            BinanceMode::Demo,
+            &mut sequence,
+            &snapshot,
+            Message::Text(payload.clone().into()),
+        )
+        .expect("handle force order");
+
+        let mut statement = connection
+            .prepare(
+                "SELECT event_id, mode, symbol, force_side, price, qty, notional, raw_payload
+                 FROM raw_liquidation_events",
+            )
+            .expect("prepare query");
+        let row = statement
+            .query_row([], |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, f64>(4)?,
+                    row.get::<_, f64>(5)?,
+                    row.get::<_, f64>(6)?,
+                    row.get::<_, String>(7)?,
+                ))
+            })
+            .expect("fetch inserted liquidation");
+        assert_eq!(row.0, 1);
+        assert_eq!(row.1, "demo");
+        assert_eq!(row.2, "BTCUSDT");
+        assert_eq!(row.3, "SELL");
+        assert_eq!(row.4, 68_250.5);
+        assert_eq!(row.5, 0.125);
+        assert_eq!(row.6, 8_531.3125);
+        assert_eq!(row.7, payload);
+        assert_eq!(sequence, 1);
+
+        let snapshot = snapshot.lock().expect("snapshot lock");
+        assert_eq!(snapshot.metrics.liquidation_events, 1);
+        assert_eq!(
+            snapshot.metrics.last_liquidation_event_time.as_deref(),
+            Some("2024-03-09 16:00:00.123")
+        );
+        assert_eq!(
+            snapshot.metrics.top_liquidation_symbols,
+            vec!["BTCUSDT:1".to_string()]
+        );
+        assert!(snapshot.last_error.is_none());
+    }
 }

--- a/src/storage/postgres_market_data.rs
+++ b/src/storage/postgres_market_data.rs
@@ -1,6 +1,8 @@
+use std::path::Path;
+
 use chrono::{NaiveDate, TimeZone, Utc};
 use duckdb::{params, Connection as DuckConnection};
-use postgres::{Client, NoTls};
+use postgres::{Client, GenericClient, NoTls};
 
 use crate::app::bootstrap::BinanceMode;
 use crate::backtest_app::runner::{BacktestReport, BacktestTrade};
@@ -9,6 +11,7 @@ use crate::error::storage_error::StorageError;
 use crate::record::coordination::RecorderCoordination;
 
 pub const POSTGRES_MARKET_DATA_SCHEMA_VERSION: &str = MARKET_DATA_SCHEMA_VERSION;
+pub const SHARED_MARKET_DATA_MODE: &str = "shared";
 
 const POSTGRES_MARKET_DATA_SCHEMA_SQL: &str = r#"
 CREATE TABLE IF NOT EXISTS schema_metadata (
@@ -19,7 +22,6 @@ CREATE TABLE IF NOT EXISTS schema_metadata (
 
 CREATE TABLE IF NOT EXISTS raw_liquidation_events (
   event_id BIGSERIAL PRIMARY KEY,
-  mode TEXT NOT NULL,
   product TEXT NOT NULL,
   symbol TEXT NOT NULL,
   event_time TIMESTAMPTZ NOT NULL,
@@ -32,11 +34,10 @@ CREATE TABLE IF NOT EXISTS raw_liquidation_events (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS raw_liquidation_events_natural_idx
-ON raw_liquidation_events (mode, product, symbol, event_time, force_side, price, qty);
+ON raw_liquidation_events (product, symbol, event_time, force_side, price, qty);
 
 CREATE TABLE IF NOT EXISTS raw_book_ticker (
   tick_id BIGSERIAL PRIMARY KEY,
-  mode TEXT NOT NULL,
   symbol TEXT NOT NULL,
   event_time TIMESTAMPTZ NOT NULL,
   receive_time TIMESTAMPTZ NOT NULL,
@@ -47,11 +48,10 @@ CREATE TABLE IF NOT EXISTS raw_book_ticker (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS raw_book_ticker_natural_idx
-ON raw_book_ticker (mode, symbol, event_time, bid, ask, bid_qty, ask_qty);
+ON raw_book_ticker (symbol, event_time, bid, ask, bid_qty, ask_qty);
 
 CREATE TABLE IF NOT EXISTS raw_agg_trades (
   trade_id BIGSERIAL PRIMARY KEY,
-  mode TEXT NOT NULL,
   symbol TEXT NOT NULL,
   event_time TIMESTAMPTZ NOT NULL,
   receive_time TIMESTAMPTZ NOT NULL,
@@ -61,11 +61,10 @@ CREATE TABLE IF NOT EXISTS raw_agg_trades (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS raw_agg_trades_natural_idx
-ON raw_agg_trades (mode, symbol, event_time, price, qty, is_buyer_maker);
+ON raw_agg_trades (symbol, event_time, price, qty, is_buyer_maker);
 
 CREATE TABLE IF NOT EXISTS raw_klines (
   kline_id BIGSERIAL PRIMARY KEY,
-  mode TEXT NOT NULL,
   product TEXT NOT NULL,
   symbol TEXT NOT NULL,
   interval_name TEXT NOT NULL,
@@ -84,11 +83,14 @@ CREATE TABLE IF NOT EXISTS raw_klines (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS raw_klines_natural_idx
-ON raw_klines (mode, product, symbol, interval_name, open_time);
+ON raw_klines (product, symbol, interval_name, open_time);
+
+CREATE INDEX IF NOT EXISTS raw_klines_chart_idx
+ON raw_klines (interval_name, symbol, open_time)
+INCLUDE (close, close_time, volume);
 
 CREATE TABLE IF NOT EXISTS backtest_runs (
   export_run_id BIGSERIAL PRIMARY KEY,
-  source_db_path TEXT NOT NULL,
   source_run_id BIGINT NOT NULL,
   exported_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
   mode TEXT NOT NULL,
@@ -96,6 +98,7 @@ CREATE TABLE IF NOT EXISTS backtest_runs (
   instrument TEXT NOT NULL,
   from_date DATE NOT NULL,
   to_date DATE NOT NULL,
+  source_db_path TEXT NOT NULL,
   liquidation_events BIGINT NOT NULL,
   book_ticker_events BIGINT NOT NULL,
   agg_trade_events BIGINT NOT NULL,
@@ -116,15 +119,14 @@ CREATE TABLE IF NOT EXISTS backtest_runs (
   win_rate_assumption DOUBLE PRECISION NOT NULL,
   r_multiple DOUBLE PRECISION NOT NULL,
   max_entry_slippage_pct DOUBLE PRECISION NOT NULL,
-  stop_distance_pct DOUBLE PRECISION NOT NULL,
-  UNIQUE (source_db_path, source_run_id)
+  stop_distance_pct DOUBLE PRECISION NOT NULL
 );
 
-CREATE INDEX IF NOT EXISTS backtest_runs_lookup_idx
+CREATE INDEX IF NOT EXISTS backtest_runs_mode_lookup_idx
 ON backtest_runs (mode, instrument, template, export_run_id DESC);
 
 CREATE TABLE IF NOT EXISTS backtest_trades (
-  export_run_id BIGINT NOT NULL REFERENCES backtest_runs(export_run_id) ON DELETE CASCADE,
+  export_run_id BIGINT NOT NULL REFERENCES backtest_runs (export_run_id) ON DELETE CASCADE,
   trade_id BIGINT NOT NULL,
   trigger_time TIMESTAMPTZ NOT NULL,
   entry_time TIMESTAMPTZ NOT NULL,
@@ -141,11 +143,11 @@ CREATE TABLE IF NOT EXISTS backtest_trades (
   PRIMARY KEY (export_run_id, trade_id)
 );
 
-CREATE INDEX IF NOT EXISTS backtest_trades_exit_time_idx
+CREATE INDEX IF NOT EXISTS backtest_trades_exit_lookup_idx
 ON backtest_trades (export_run_id, exit_time);
 
 CREATE TABLE IF NOT EXISTS backtest_equity_points (
-  export_run_id BIGINT NOT NULL REFERENCES backtest_runs(export_run_id) ON DELETE CASCADE,
+  export_run_id BIGINT NOT NULL REFERENCES backtest_runs (export_run_id) ON DELETE CASCADE,
   point_id BIGINT NOT NULL,
   event_time TIMESTAMPTZ NOT NULL,
   equity DOUBLE PRECISION NOT NULL,
@@ -153,8 +155,45 @@ CREATE TABLE IF NOT EXISTS backtest_equity_points (
   PRIMARY KEY (export_run_id, point_id)
 );
 
-CREATE INDEX IF NOT EXISTS backtest_equity_points_time_idx
+CREATE INDEX IF NOT EXISTS backtest_equity_points_time_lookup_idx
 ON backtest_equity_points (export_run_id, event_time);
+"#;
+
+const POSTGRES_MARKET_DATA_MODELESS_MIGRATION_SQL: &str = r#"
+DROP INDEX IF EXISTS raw_liquidation_events_natural_idx;
+DROP INDEX IF EXISTS raw_book_ticker_natural_idx;
+DROP INDEX IF EXISTS raw_agg_trades_natural_idx;
+DROP INDEX IF EXISTS raw_klines_natural_idx;
+DROP INDEX IF EXISTS raw_klines_chart_idx;
+
+ALTER TABLE IF EXISTS raw_liquidation_events DROP COLUMN IF EXISTS mode CASCADE;
+ALTER TABLE IF EXISTS raw_book_ticker DROP COLUMN IF EXISTS mode CASCADE;
+ALTER TABLE IF EXISTS raw_agg_trades DROP COLUMN IF EXISTS mode CASCADE;
+ALTER TABLE IF EXISTS raw_klines DROP COLUMN IF EXISTS mode CASCADE;
+
+DELETE FROM raw_klines a
+USING raw_klines b
+WHERE a.kline_id > b.kline_id
+  AND a.product = b.product
+  AND a.symbol = b.symbol
+  AND a.interval_name = b.interval_name
+  AND a.open_time = b.open_time;
+
+CREATE UNIQUE INDEX IF NOT EXISTS raw_liquidation_events_natural_idx
+ON raw_liquidation_events (product, symbol, event_time, force_side, price, qty);
+
+CREATE UNIQUE INDEX IF NOT EXISTS raw_book_ticker_natural_idx
+ON raw_book_ticker (symbol, event_time, bid, ask, bid_qty, ask_qty);
+
+CREATE UNIQUE INDEX IF NOT EXISTS raw_agg_trades_natural_idx
+ON raw_agg_trades (symbol, event_time, price, qty, is_buyer_maker);
+
+CREATE UNIQUE INDEX IF NOT EXISTS raw_klines_natural_idx
+ON raw_klines (product, symbol, interval_name, open_time);
+
+CREATE INDEX IF NOT EXISTS raw_klines_chart_idx
+ON raw_klines (interval_name, symbol, open_time)
+INCLUDE (close, close_time, volume);
 "#;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -174,7 +213,6 @@ impl CollectorStorageBackend {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PostgresKlineRecord {
-    pub mode: String,
     pub product: String,
     pub symbol: String,
     pub interval_name: String,
@@ -194,7 +232,6 @@ pub struct PostgresKlineRecord {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PostgresLiquidationRecord {
-    pub mode: String,
     pub product: String,
     pub symbol: String,
     pub event_time_ms: i64,
@@ -208,7 +245,6 @@ pub struct PostgresLiquidationRecord {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PostgresBookTickerRecord {
-    pub mode: String,
     pub symbol: String,
     pub event_time_ms: i64,
     pub receive_time_ms: i64,
@@ -220,7 +256,6 @@ pub struct PostgresBookTickerRecord {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PostgresAggTradeRecord {
-    pub mode: String,
     pub symbol: String,
     pub event_time_ms: i64,
     pub receive_time_ms: i64,
@@ -282,21 +317,146 @@ pub struct PostgresToDuckDbSnapshotReport {
     pub agg_trade_rows: usize,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PostgresBacktestExportReport {
-    pub export_run_id: i64,
-    pub source_run_id: i64,
-    pub trade_rows: usize,
-    pub equity_point_rows: usize,
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct PostgresMarketFreshness {
+    pub last_liquidation_event_time: Option<String>,
+    pub liquidation_age_sec: Option<i64>,
+    pub last_book_ticker_event_time: Option<String>,
+    pub book_ticker_age_sec: Option<i64>,
+    pub last_agg_trade_event_time: Option<String>,
+    pub agg_trade_age_sec: Option<i64>,
+    pub last_kline_close_time: Option<String>,
+    pub kline_age_sec: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct BacktestEquityPoint {
+    point_id: i64,
+    event_time_ms: i64,
+    equity: f64,
+    cumulative_net_pnl: f64,
 }
 
 pub fn postgres_url_from_env() -> Result<String, StorageError> {
+    if let Some(url) = read_postgres_url_from_runtime_env() {
+        return Ok(url);
+    }
+
+    let dotenv_values = read_postgres_values_from_dotenv();
+    if let Some(url) = build_postgres_url_from_values(&dotenv_values) {
+        return Ok(url);
+    }
+
+    Err(StorageError::WriteFailedWithContext {
+        message: "missing PostgreSQL URL; set SANDBOX_QUANT_POSTGRES_URL, DATABASE_URL, or POSTGRES_* runtime vars".to_string(),
+    })
+}
+
+fn read_postgres_url_from_runtime_env() -> Option<String> {
     std::env::var("SANDBOX_QUANT_POSTGRES_URL")
-        .or_else(|_| std::env::var("DATABASE_URL"))
-        .map_err(|_| StorageError::WriteFailedWithContext {
-            message: "missing PostgreSQL URL; set SANDBOX_QUANT_POSTGRES_URL or DATABASE_URL"
-                .to_string(),
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            std::env::var("DATABASE_URL")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
         })
+        .or_else(|| {
+            let values = read_postgres_values_from_env();
+            build_postgres_url_from_values(&values)
+        })
+}
+
+fn read_postgres_values_from_env() -> Vec<(String, String)> {
+    [
+        "POSTGRES_USER",
+        "POSTGRES_PASSWORD",
+        "POSTGRES_PORT",
+        "POSTGRES_DB",
+        "POSTGRES_PUBLISH_ADDRESS",
+        "POSTGRES_HOST",
+    ]
+    .into_iter()
+    .filter_map(|key| std::env::var(key).ok().map(|value| (key.to_string(), value)))
+    .collect()
+}
+
+fn read_postgres_values_from_dotenv() -> Vec<(String, String)> {
+    dotenv_candidates()
+        .into_iter()
+        .find_map(|path| read_selected_dotenv_values(&path))
+        .unwrap_or_default()
+}
+
+fn dotenv_candidates() -> Vec<std::path::PathBuf> {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    vec![
+        Path::new(".env").to_path_buf(),
+        manifest_dir.join(".env"),
+        Path::new("ops/grafana/.env").to_path_buf(),
+        manifest_dir.join("ops/grafana/.env"),
+    ]
+}
+
+fn read_selected_dotenv_values(path: &Path) -> Option<Vec<(String, String)>> {
+    if !path.exists() {
+        return None;
+    }
+    let entries = dotenvy::from_path_iter(path).ok()?;
+    let allowed = [
+        "SANDBOX_QUANT_POSTGRES_URL",
+        "DATABASE_URL",
+        "POSTGRES_USER",
+        "POSTGRES_PASSWORD",
+        "POSTGRES_PORT",
+        "POSTGRES_DB",
+        "POSTGRES_PUBLISH_ADDRESS",
+        "POSTGRES_HOST",
+    ];
+    let values = entries
+        .filter_map(Result::ok)
+        .filter(|(key, _)| allowed.contains(&key.as_str()))
+        .collect::<Vec<_>>();
+    Some(values)
+}
+
+fn build_postgres_url_from_values(values: &[(String, String)]) -> Option<String> {
+    let direct_url = find_value(values, "SANDBOX_QUANT_POSTGRES_URL")
+        .or_else(|| find_value(values, "DATABASE_URL"));
+    if let Some(url) = direct_url.filter(|value| !value.trim().is_empty()) {
+        return Some(url);
+    }
+
+    let user = find_value(values, "POSTGRES_USER")?;
+    let password = find_value(values, "POSTGRES_PASSWORD")?;
+    let database = find_value(values, "POSTGRES_DB")?;
+    let host = find_value(values, "POSTGRES_HOST")
+        .or_else(|| find_value(values, "POSTGRES_PUBLISH_ADDRESS"))
+        .map(normalize_postgres_host)
+        .unwrap_or_else(|| "127.0.0.1".to_string());
+    let port = find_value(values, "POSTGRES_PORT").unwrap_or_else(|| "5432".to_string());
+
+    Some(format!(
+        "postgres://{}:{}@{}:{}/{}",
+        user, password, host, port, database
+    ))
+}
+
+fn find_value(values: &[(String, String)], key: &str) -> Option<String> {
+    values.iter().find_map(|(entry_key, entry_value)| {
+        if entry_key == key {
+            Some(entry_value.clone())
+        } else {
+            None
+        }
+    })
+}
+
+fn normalize_postgres_host(host: String) -> String {
+    match host.trim() {
+        "" | "0.0.0.0" => "127.0.0.1".to_string(),
+        value => value.to_string(),
+    }
 }
 
 pub fn connect(url: &str) -> Result<Client, StorageError> {
@@ -310,6 +470,12 @@ pub fn init_schema(client: &mut Client, url: &str) -> Result<Option<String>, Sto
     let previous_version = existing_schema_version(client)?;
     client
         .batch_execute(POSTGRES_MARKET_DATA_SCHEMA_SQL)
+        .map_err(|error| StorageError::DatabaseInitFailed {
+            path: mask_postgres_url(url),
+            message: error.to_string(),
+        })?;
+    client
+        .batch_execute(POSTGRES_MARKET_DATA_MODELESS_MIGRATION_SQL)
         .map_err(|error| StorageError::DatabaseInitFailed {
             path: mask_postgres_url(url),
             message: error.to_string(),
@@ -329,25 +495,140 @@ pub fn init_schema(client: &mut Client, url: &str) -> Result<Option<String>, Sto
     Ok(previous_version)
 }
 
+pub fn ensure_recorder_schema_ready(client: &mut Client, url: &str) -> Result<(), StorageError> {
+    for table in [
+        "raw_liquidation_events",
+        "raw_book_ticker",
+        "raw_agg_trades",
+    ] {
+        let exists = client
+            .query_one(
+                "SELECT EXISTS (
+                    SELECT 1
+                    FROM information_schema.tables
+                    WHERE table_schema = 'public' AND table_name = $1
+                )",
+                &[&table],
+            )
+            .map_err(|error| StorageError::DatabaseInitFailed {
+                path: mask_postgres_url(url),
+                message: error.to_string(),
+            })?
+            .get::<_, bool>(0);
+        if !exists {
+            return Err(StorageError::DatabaseInitFailed {
+                path: mask_postgres_url(url),
+                message: format!(
+                    "required recorder table missing: {table}; run the PostgreSQL schema bootstrap/migration first"
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+pub fn export_backtest_report(
+    client: &mut Client,
+    report: &BacktestReport,
+) -> Result<i64, StorageError> {
+    let closed_trades = report
+        .trades
+        .iter()
+        .filter(|trade| trade.net_pnl.is_some())
+        .count() as i64;
+    let equity_points = build_backtest_equity_points(report)?;
+    let mode = report.mode.as_str().to_string();
+    let template = report.template.slug().to_string();
+    let instrument = report.instrument.clone();
+    let source_db_path = report.db_path.display().to_string();
+    let source_run_id = match report.run_id {
+        Some(run_id) => run_id,
+        None => next_backtest_source_run_id(client, &source_db_path)?,
+    };
+    let mut transaction = client.transaction().map_err(storage_err)?;
+    let export_run_id: i64 = transaction
+        .query_one(
+            "INSERT INTO backtest_runs (
+                source_run_id, exported_at, mode, template, instrument, from_date, to_date,
+                source_db_path, liquidation_events, book_ticker_events, agg_trade_events,
+                derived_kline_1s_bars, trigger_count, closed_trades, open_trades, wins,
+                losses, skipped_triggers, starting_equity, ending_equity, net_pnl,
+                observed_win_rate, average_net_pnl, configured_expected_value, risk_pct,
+                win_rate_assumption, r_multiple, max_entry_slippage_pct, stop_distance_pct
+             ) VALUES (
+                $1, CURRENT_TIMESTAMP, $2, $3, $4, $5, $6,
+                $7, $8, $9, $10,
+                $11, $12, $13, $14, $15,
+                $16, $17, $18, $19, $20,
+                $21, $22, $23, $24,
+                $25, $26, $27, $28
+             )
+             RETURNING export_run_id",
+            &[
+                &source_run_id,
+                &mode,
+                &template,
+                &instrument,
+                &report.from,
+                &report.to,
+                &source_db_path,
+                &(report.dataset.liquidation_events as i64),
+                &(report.dataset.book_ticker_events as i64),
+                &(report.dataset.agg_trade_events as i64),
+                &(report.dataset.derived_kline_1s_bars as i64),
+                &(report.trigger_count as i64),
+                &closed_trades,
+                &(report.open_trades as i64),
+                &(report.wins as i64),
+                &(report.losses as i64),
+                &(report.skipped_triggers as i64),
+                &report.starting_equity,
+                &report.ending_equity,
+                &report.net_pnl,
+                &report.observed_win_rate,
+                &report.average_net_pnl,
+                &report.configured_expected_value,
+                &report.config.risk_pct,
+                &report.config.win_rate_assumption,
+                &report.config.r_multiple,
+                &report.config.max_entry_slippage_pct,
+                &report.config.stop_distance_pct,
+            ],
+        )
+        .map_err(|error| StorageError::WriteFailedWithContext {
+            message: format!("insert backtest_runs failed: {error}"),
+        })?
+        .get(0);
+    for trade in &report.trades {
+        insert_backtest_trade(&mut transaction, export_run_id, trade)?;
+    }
+    for point in equity_points {
+        insert_backtest_equity_point(&mut transaction, export_run_id, &point)?;
+    }
+    transaction.commit().map_err(storage_err)?;
+    Ok(export_run_id)
+}
+
 pub fn insert_kline(client: &mut Client, record: &PostgresKlineRecord) -> Result<(), StorageError> {
+    let open_time = timestamp_from_millis(record.open_time_ms)?;
+    let close_time = timestamp_from_millis(record.close_time_ms)?;
     client
         .execute(
             "INSERT INTO raw_klines (
-                mode, product, symbol, interval_name, open_time, close_time,
+                product, symbol, interval_name, open_time, close_time,
                 open, high, low, close, volume, quote_volume, trade_count,
                 taker_buy_base_volume, taker_buy_quote_volume, raw_payload
              ) VALUES (
-                $1, $2, $3, $4, to_timestamp($5 / 1000.0), to_timestamp($6 / 1000.0),
-                $7, $8, $9, $10, $11, $12, $13, $14, $15, $16
+                $1, $2, $3, $4, $5,
+                $6, $7, $8, $9, $10, $11, $12, $13, $14, $15
              )
-             ON CONFLICT (mode, product, symbol, interval_name, open_time) DO NOTHING",
+             ON CONFLICT (product, symbol, interval_name, open_time) DO NOTHING",
             &[
-                &record.mode,
                 &record.product,
                 &record.symbol,
                 &record.interval_name,
-                &record.open_time_ms,
-                &record.close_time_ms,
+                &open_time,
+                &close_time,
                 &record.open,
                 &record.high,
                 &record.low,
@@ -368,20 +649,21 @@ pub fn insert_liquidation(
     client: &mut Client,
     record: &PostgresLiquidationRecord,
 ) -> Result<(), StorageError> {
+    let event_time = timestamp_from_millis(record.event_time_ms)?;
+    let receive_time = timestamp_from_millis(record.receive_time_ms)?;
     client
         .execute(
             "INSERT INTO raw_liquidation_events (
-                mode, product, symbol, event_time, receive_time, force_side, price, qty, notional, raw_payload
+                product, symbol, event_time, receive_time, force_side, price, qty, notional, raw_payload
              ) VALUES (
-                $1, $2, $3, to_timestamp($4 / 1000.0), to_timestamp($5 / 1000.0), $6, $7, $8, $9, $10
+                $1, $2, $3, $4, $5, $6, $7, $8, $9
              )
-             ON CONFLICT (mode, product, symbol, event_time, force_side, price, qty) DO NOTHING",
+             ON CONFLICT (product, symbol, event_time, force_side, price, qty) DO NOTHING",
             &[
-                &record.mode,
                 &record.product,
                 &record.symbol,
-                &record.event_time_ms,
-                &record.receive_time_ms,
+                &event_time,
+                &receive_time,
                 &record.force_side,
                 &record.price,
                 &record.qty,
@@ -397,19 +679,20 @@ pub fn insert_book_ticker(
     client: &mut Client,
     record: &PostgresBookTickerRecord,
 ) -> Result<(), StorageError> {
+    let event_time = timestamp_from_millis(record.event_time_ms)?;
+    let receive_time = timestamp_from_millis(record.receive_time_ms)?;
     client
         .execute(
             "INSERT INTO raw_book_ticker (
-                mode, symbol, event_time, receive_time, bid, bid_qty, ask, ask_qty
+                symbol, event_time, receive_time, bid, bid_qty, ask, ask_qty
              ) VALUES (
-                $1, $2, to_timestamp($3 / 1000.0), to_timestamp($4 / 1000.0), $5, $6, $7, $8
+                $1, $2, $3, $4, $5, $6, $7
              )
-             ON CONFLICT (mode, symbol, event_time, bid, ask, bid_qty, ask_qty) DO NOTHING",
+             ON CONFLICT (symbol, event_time, bid, ask, bid_qty, ask_qty) DO NOTHING",
             &[
-                &record.mode,
                 &record.symbol,
-                &record.event_time_ms,
-                &record.receive_time_ms,
+                &event_time,
+                &receive_time,
                 &record.bid,
                 &record.bid_qty,
                 &record.ask,
@@ -424,19 +707,20 @@ pub fn insert_agg_trade(
     client: &mut Client,
     record: &PostgresAggTradeRecord,
 ) -> Result<(), StorageError> {
+    let event_time = timestamp_from_millis(record.event_time_ms)?;
+    let receive_time = timestamp_from_millis(record.receive_time_ms)?;
     client
         .execute(
             "INSERT INTO raw_agg_trades (
-                mode, symbol, event_time, receive_time, price, qty, is_buyer_maker
+                symbol, event_time, receive_time, price, qty, is_buyer_maker
              ) VALUES (
-                $1, $2, to_timestamp($3 / 1000.0), to_timestamp($4 / 1000.0), $5, $6, $7
+                $1, $2, $3, $4, $5, $6
              )
-             ON CONFLICT (mode, symbol, event_time, price, qty, is_buyer_maker) DO NOTHING",
+             ON CONFLICT (symbol, event_time, price, qty, is_buyer_maker) DO NOTHING",
             &[
-                &record.mode,
                 &record.symbol,
-                &record.event_time_ms,
-                &record.receive_time_ms,
+                &event_time,
+                &receive_time,
                 &record.price,
                 &record.qty,
                 &record.is_buyer_maker,
@@ -450,7 +734,7 @@ pub fn metrics_for_postgres_url(
     url: &str,
 ) -> Result<crate::dataset::types::RecorderMetrics, StorageError> {
     let mut client = connect(url)?;
-    let _ = init_schema(&mut client, url)?;
+    ensure_recorder_schema_ready(&mut client, url)?;
     Ok(crate::dataset::types::RecorderMetrics {
         liquidation_events: query_count(&mut client, "raw_liquidation_events")?,
         book_ticker_events: query_count(&mut client, "raw_book_ticker")?,
@@ -475,6 +759,32 @@ pub fn metrics_for_postgres_url(
         top_liquidation_symbols: query_top_symbols(&mut client, "raw_liquidation_events")?,
         top_book_ticker_symbols: query_top_symbols(&mut client, "raw_book_ticker")?,
         top_agg_trade_symbols: query_top_symbols(&mut client, "raw_agg_trades")?,
+    })
+}
+
+pub fn market_freshness_for_postgres_url(
+    url: &str,
+    interval_name: &str,
+) -> Result<PostgresMarketFreshness, StorageError> {
+    let mut client = connect(url)?;
+    ensure_recorder_schema_ready(&mut client, url)?;
+    let (last_liquidation_event_time, liquidation_age_sec) =
+        query_latest_timestamp_and_age(&mut client, "raw_liquidation_events", "event_time")?;
+    let (last_book_ticker_event_time, book_ticker_age_sec) =
+        query_latest_timestamp_and_age(&mut client, "raw_book_ticker", "event_time")?;
+    let (last_agg_trade_event_time, agg_trade_age_sec) =
+        query_latest_timestamp_and_age(&mut client, "raw_agg_trades", "event_time")?;
+    let (last_kline_close_time, kline_age_sec) =
+        query_latest_kline_timestamp_and_age(&mut client, interval_name)?;
+    Ok(PostgresMarketFreshness {
+        last_liquidation_event_time,
+        liquidation_age_sec,
+        last_book_ticker_event_time,
+        book_ticker_age_sec,
+        last_agg_trade_event_time,
+        agg_trade_age_sec,
+        last_kline_close_time,
+        kline_age_sec,
     })
 }
 
@@ -532,6 +842,155 @@ pub fn load_summary(
     })
 }
 
+pub fn latest_shared_kline_open_time_ms(
+    client: &mut Client,
+    product: &str,
+    symbol: &str,
+    interval_name: &str,
+) -> Result<Option<i64>, StorageError> {
+    client
+        .query_opt(
+            "SELECT (EXTRACT(EPOCH FROM MAX(open_time)) * 1000)::BIGINT
+             FROM raw_klines
+             WHERE product = $1 AND symbol = $2 AND interval_name = $3",
+            &[&product, &symbol, &interval_name],
+        )
+        .map_err(storage_err)
+        .map(|row| row.and_then(|row| row.get::<_, Option<i64>>(0)))
+}
+
+pub fn backtest_summary_for_postgres_url(
+    url: &str,
+    _mode: BinanceMode,
+    symbol: &str,
+    from: NaiveDate,
+    to: NaiveDate,
+) -> Result<crate::dataset::types::BacktestDatasetSummary, StorageError> {
+    let mut client = connect(url)?;
+    init_schema(&mut client, url)?;
+    let symbol_text = symbol.to_string();
+    let from_time_ms = from
+        .and_hms_opt(0, 0, 0)
+        .ok_or_else(|| StorageError::WriteFailedWithContext {
+            message: format!("invalid backtest from date: {from}"),
+        })?
+        .and_utc()
+        .timestamp_millis() as f64;
+    let to_time_ms = to
+        .and_hms_opt(23, 59, 59)
+        .ok_or_else(|| StorageError::WriteFailedWithContext {
+            message: format!("invalid backtest to date: {to}"),
+        })?
+        .and_utc()
+        .timestamp_millis() as f64;
+    let symbol_found = client
+        .query_one(
+            "SELECT EXISTS(
+                SELECT 1 FROM raw_klines WHERE symbol = $1
+            )",
+            &[&symbol_text],
+        )
+        .map_err(storage_err)?
+        .get::<_, bool>(0);
+
+    let kline_count = postgres_count_in_range(
+        &mut client,
+        "raw_klines",
+        "open_time",
+        &symbol_text,
+        from_time_ms,
+        to_time_ms,
+    )?;
+
+    Ok(crate::dataset::types::BacktestDatasetSummary {
+        mode: _mode,
+        symbol: symbol.to_string(),
+        symbol_found,
+        from: from.to_string(),
+        to: to.to_string(),
+        liquidation_events: 0,
+        book_ticker_events: 0,
+        agg_trade_events: 0,
+        derived_kline_1s_bars: kline_count,
+    })
+}
+
+pub fn load_raw_kline_rows_for_postgres_url(
+    url: &str,
+    _mode: BinanceMode,
+    symbol: &str,
+    from: NaiveDate,
+    to: NaiveDate,
+) -> Result<Option<(String, Vec<crate::dataset::types::DerivedKlineRow>)>, StorageError> {
+    let mut client = connect(url)?;
+    init_schema(&mut client, url)?;
+    let symbol_text = symbol.to_string();
+    let from_time_ms = from
+        .and_hms_opt(0, 0, 0)
+        .ok_or_else(|| StorageError::WriteFailedWithContext {
+            message: format!("invalid backtest from date: {from}"),
+        })?
+        .and_utc()
+        .timestamp_millis() as f64;
+    let to_time_ms = to
+        .and_hms_opt(23, 59, 59)
+        .ok_or_else(|| StorageError::WriteFailedWithContext {
+            message: format!("invalid backtest to date: {to}"),
+        })?
+        .and_utc()
+        .timestamp_millis() as f64;
+
+    let interval_rows = client
+        .query(
+            "SELECT DISTINCT interval_name
+             FROM raw_klines
+             WHERE symbol = $1
+               AND open_time >= to_timestamp($2::double precision / 1000.0)
+               AND open_time <= to_timestamp($3::double precision / 1000.0)",
+            &[&symbol_text, &from_time_ms, &to_time_ms],
+        )
+        .map_err(storage_err)?;
+    let interval = interval_rows
+        .into_iter()
+        .map(|row| row.get::<_, String>(0))
+        .min_by_key(|value| raw_kline_interval_rank(value));
+    let Some(interval) = interval else {
+        return Ok(None);
+    };
+
+    let rows = client
+        .query(
+            "SELECT
+                (EXTRACT(EPOCH FROM open_time) * 1000)::BIGINT AS open_time_ms,
+                (EXTRACT(EPOCH FROM close_time) * 1000)::BIGINT AS close_time_ms,
+                open, high, low, close, volume, quote_volume, trade_count
+             FROM raw_klines
+             WHERE symbol = $1
+               AND interval_name = $2
+               AND open_time >= to_timestamp($3::double precision / 1000.0)
+               AND open_time <= to_timestamp($4::double precision / 1000.0)
+             ORDER BY open_time ASC",
+            &[&symbol_text, &interval, &from_time_ms, &to_time_ms],
+        )
+        .map_err(storage_err)?;
+    let result = rows
+        .into_iter()
+        .map(|row| crate::dataset::types::DerivedKlineRow {
+            open_time_ms: row.get(0),
+            close_time_ms: row.get(1),
+            open: row.get(2),
+            high: row.get(3),
+            low: row.get(4),
+            close: row.get(5),
+            volume: row.get(6),
+            quote_volume: row.get(7),
+            trade_count: row.get::<_, i64>(8).max(0) as u64,
+        })
+        .collect::<Vec<_>>();
+
+    Ok(Some((interval, result)))
+}
+
 pub fn export_snapshot_to_duckdb(
     config: &PostgresToDuckDbSnapshotConfig,
 ) -> Result<PostgresToDuckDbSnapshotReport, StorageError> {
@@ -546,8 +1005,26 @@ pub fn export_snapshot_to_duckdb(
             message: error.to_string(),
         })?;
 
+    let product = config.product.clone();
+    let interval_name = config.interval_name.clone();
     let from_ts = format!("{} 00:00:00", config.from);
     let to_ts = format!("{} 23:59:59", config.to);
+    let from_time_ms = config
+        .from
+        .and_hms_opt(0, 0, 0)
+        .ok_or_else(|| StorageError::WriteFailedWithContext {
+            message: format!("invalid snapshot from date: {}", config.from),
+        })?
+        .and_utc()
+        .timestamp_millis() as f64;
+    let to_time_ms = config
+        .to
+        .and_hms_opt(23, 59, 59)
+        .ok_or_else(|| StorageError::WriteFailedWithContext {
+            message: format!("invalid snapshot to date: {}", config.to),
+        })?
+        .and_utc()
+        .timestamp_millis() as f64;
 
     let mut kline_rows = 0usize;
     let mut liquidation_rows = 0usize;
@@ -559,7 +1036,6 @@ pub fn export_snapshot_to_duckdb(
             if config.include_klines {
                 clear_duckdb_klines(
                     &duck,
-                    config.mode,
                     symbol,
                     config.product.as_deref(),
                     config.interval_name.as_deref(),
@@ -568,13 +1044,13 @@ pub fn export_snapshot_to_duckdb(
                 )?;
             }
             if config.include_liquidations {
-                clear_duckdb_liquidations(&duck, config.mode, symbol, &from_ts, &to_ts)?;
+                clear_duckdb_liquidations(&duck, symbol, &from_ts, &to_ts)?;
             }
             if config.include_book_tickers {
-                clear_duckdb_book_tickers(&duck, config.mode, symbol, &from_ts, &to_ts)?;
+                clear_duckdb_book_tickers(&duck, symbol, &from_ts, &to_ts)?;
             }
             if config.include_agg_trades {
-                clear_duckdb_agg_trades(&duck, config.mode, symbol, &from_ts, &to_ts)?;
+                clear_duckdb_agg_trades(&duck, symbol, &from_ts, &to_ts)?;
             }
         }
 
@@ -587,23 +1063,17 @@ pub fn export_snapshot_to_duckdb(
                             open, high, low, close, volume, quote_volume, trade_count,
                             taker_buy_base_volume, taker_buy_quote_volume, raw_payload
                      FROM raw_klines
-                     WHERE mode = $1
-                       AND symbol = $2
-                       AND open_time >= CAST($3 AS TIMESTAMPTZ)
-                       AND open_time <= CAST($4 AS TIMESTAMPTZ)
-                       AND ($5::TEXT IS NULL OR product = $5)
-                       AND ($6::TEXT IS NULL OR interval_name = $6)
-                     ORDER BY open_time ASC",
-                    &[
-                        &config.mode.as_str(),
-                        &symbol,
-                        &from_ts,
-                        &to_ts,
-                        &config.product,
-                        &config.interval_name,
-                    ],
+                     WHERE symbol = $1
+                       AND open_time >= to_timestamp($2::double precision / 1000.0)
+                       AND open_time <= to_timestamp($3::double precision / 1000.0)
+                       AND ($4::TEXT IS NULL OR product = $4)
+                       AND ($5::TEXT IS NULL OR interval_name = $5)
+                    ORDER BY open_time ASC",
+                    &[symbol, &from_time_ms, &to_time_ms, &product, &interval_name],
                 )
-                .map_err(storage_err)?;
+                .map_err(|error| StorageError::WriteFailedWithContext {
+                    message: format!("query raw_klines from postgres failed: {error}"),
+                })?;
 
             let mut next_id = next_duckdb_kline_id(&duck)?;
             for row in rows {
@@ -612,13 +1082,13 @@ pub fn export_snapshot_to_duckdb(
                         kline_id, mode, product, symbol, interval, open_time, close_time,
                         open, high, low, close, volume, quote_volume, trade_count,
                         taker_buy_base_volume, taker_buy_quote_volume, raw_payload
-                     ) VALUES (
+                    ) VALUES (
                         ?, ?, ?, ?, ?, to_timestamp(? / 1000.0), to_timestamp(? / 1000.0),
                         ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
-                     )",
+                    )",
                     params![
                         next_id,
-                        config.mode.as_str(),
+                        SHARED_MARKET_DATA_MODE.to_string(),
                         row.get::<_, String>(0),
                         row.get::<_, String>(1),
                         row.get::<_, String>(2),
@@ -636,7 +1106,9 @@ pub fn export_snapshot_to_duckdb(
                         row.get::<_, String>(14),
                     ],
                 )
-                .map_err(storage_err)?;
+                .map_err(|error| StorageError::WriteFailedWithContext {
+                    message: format!("insert raw_klines into duckdb failed: {error}"),
+                })?;
                 next_id += 1;
                 kline_rows += 1;
             }
@@ -650,12 +1122,11 @@ pub fn export_snapshot_to_duckdb(
                             (EXTRACT(EPOCH FROM receive_time) * 1000)::BIGINT AS receive_time_ms,
                             force_side, price, qty, notional, raw_payload
                      FROM raw_liquidation_events
-                     WHERE mode = $1
-                       AND symbol = $2
-                       AND event_time >= CAST($3 AS TIMESTAMPTZ)
-                       AND event_time <= CAST($4 AS TIMESTAMPTZ)
+                     WHERE symbol = $1
+                       AND event_time >= to_timestamp($2::double precision / 1000.0)
+                       AND event_time <= to_timestamp($3::double precision / 1000.0)
                      ORDER BY event_time ASC",
-                    &[&config.mode.as_str(), &symbol, &from_ts, &to_ts],
+                    &[symbol, &from_time_ms, &to_time_ms],
                 )
                 .map_err(storage_err)?;
             let mut next_id = next_duckdb_liquidation_event_id(&duck)?;
@@ -668,7 +1139,7 @@ pub fn export_snapshot_to_duckdb(
                      )",
                     params![
                         next_id,
-                        config.mode.as_str(),
+                        SHARED_MARKET_DATA_MODE.to_string(),
                         row.get::<_, String>(0),
                         row.get::<_, i64>(1),
                         row.get::<_, i64>(2),
@@ -693,12 +1164,11 @@ pub fn export_snapshot_to_duckdb(
                             (EXTRACT(EPOCH FROM receive_time) * 1000)::BIGINT AS receive_time_ms,
                             bid, bid_qty, ask, ask_qty
                      FROM raw_book_ticker
-                     WHERE mode = $1
-                       AND symbol = $2
-                       AND event_time >= CAST($3 AS TIMESTAMPTZ)
-                       AND event_time <= CAST($4 AS TIMESTAMPTZ)
+                     WHERE symbol = $1
+                       AND event_time >= to_timestamp($2::double precision / 1000.0)
+                       AND event_time <= to_timestamp($3::double precision / 1000.0)
                      ORDER BY event_time ASC",
-                    &[&config.mode.as_str(), &symbol, &from_ts, &to_ts],
+                    &[symbol, &from_time_ms, &to_time_ms],
                 )
                 .map_err(storage_err)?;
             let mut next_id = next_duckdb_book_ticker_id(&duck)?;
@@ -711,7 +1181,7 @@ pub fn export_snapshot_to_duckdb(
                      )",
                     params![
                         next_id,
-                        config.mode.as_str(),
+                        SHARED_MARKET_DATA_MODE.to_string(),
                         row.get::<_, String>(0),
                         row.get::<_, i64>(1),
                         row.get::<_, i64>(2),
@@ -735,12 +1205,11 @@ pub fn export_snapshot_to_duckdb(
                             (EXTRACT(EPOCH FROM receive_time) * 1000)::BIGINT AS receive_time_ms,
                             price, qty, is_buyer_maker
                      FROM raw_agg_trades
-                     WHERE mode = $1
-                       AND symbol = $2
-                       AND event_time >= CAST($3 AS TIMESTAMPTZ)
-                       AND event_time <= CAST($4 AS TIMESTAMPTZ)
+                     WHERE symbol = $1
+                       AND event_time >= to_timestamp($2::double precision / 1000.0)
+                       AND event_time <= to_timestamp($3::double precision / 1000.0)
                      ORDER BY event_time ASC",
-                    &[&config.mode.as_str(), &symbol, &from_ts, &to_ts],
+                    &[symbol, &from_time_ms, &to_time_ms],
                 )
                 .map_err(storage_err)?;
             let mut next_id = next_duckdb_agg_trade_id(&duck)?;
@@ -753,7 +1222,7 @@ pub fn export_snapshot_to_duckdb(
                      )",
                     params![
                         next_id,
-                        config.mode.as_str(),
+                        SHARED_MARKET_DATA_MODE.to_string(),
                         row.get::<_, String>(0),
                         row.get::<_, i64>(1),
                         row.get::<_, i64>(2),
@@ -786,8 +1255,8 @@ pub fn export_snapshot_to_duckdb(
             config.symbols.join(","),
             config.from.to_string(),
             config.to.to_string(),
-            config.product.as_deref(),
-            config.interval_name.as_deref(),
+            product,
+            interval_name,
             config.include_klines,
             config.include_liquidations,
             config.include_book_tickers,
@@ -799,7 +1268,9 @@ pub fn export_snapshot_to_duckdb(
             agg_trade_rows as i64,
         ],
     )
-    .map_err(storage_err)?;
+    .map_err(|error| StorageError::WriteFailedWithContext {
+        message: format!("insert snapshot_exports into duckdb failed: {error}"),
+    })?;
 
     Ok(PostgresToDuckDbSnapshotReport {
         snapshot_export_id,
@@ -811,81 +1282,144 @@ pub fn export_snapshot_to_duckdb(
     })
 }
 
-pub fn export_backtest_report_to_postgres(
-    postgres_url: &str,
-    report: &BacktestReport,
-) -> Result<PostgresBacktestExportReport, StorageError> {
-    let source_run_id = report.run_id.ok_or_else(|| StorageError::WriteFailedWithContext {
-        message: "backtest report export requires a persisted run_id".to_string(),
-    })?;
-    let mut client = connect(postgres_url)?;
-    init_schema(&mut client, postgres_url)?;
-
-    let export_run_id = upsert_backtest_run(&mut client, report, source_run_id)?;
+fn insert_backtest_trade(
+    client: &mut impl GenericClient,
+    export_run_id: i64,
+    trade: &BacktestTrade,
+) -> Result<(), StorageError> {
+    let exit_reason = trade
+        .exit_reason
+        .as_ref()
+        .map(|reason| reason.as_str().to_string());
+    let trigger_time_ms = trade.trigger_time.timestamp_millis() as f64;
+    let entry_time_ms = trade.entry_time.timestamp_millis() as f64;
+    let exit_time_ms = trade.exit_time.map(|value| value.timestamp_millis() as f64);
     client
         .execute(
-            "DELETE FROM backtest_trades WHERE export_run_id = $1",
-            &[&export_run_id],
+            "INSERT INTO backtest_trades (
+                export_run_id, trade_id, trigger_time, entry_time, entry_price, stop_price,
+                take_profit_price, qty, exit_time, exit_price, exit_reason, gross_pnl, fees, net_pnl
+             ) VALUES (
+                $1, $2, to_timestamp($3::double precision / 1000.0), to_timestamp($4::double precision / 1000.0), $5, $6,
+                $7, $8, to_timestamp($9::double precision / 1000.0), $10, $11, $12, $13, $14
+             )",
+                &[
+                    &export_run_id,
+                    &(trade.trade_id as i64),
+                    &trigger_time_ms,
+                    &entry_time_ms,
+                    &trade.entry_price,
+                    &trade.stop_price,
+                    &trade.take_profit_price,
+                    &trade.qty,
+                    &exit_time_ms,
+                    &trade.exit_price,
+                    &exit_reason,
+                    &trade.gross_pnl,
+                &trade.fees,
+                &trade.net_pnl,
+            ],
         )
-        .map_err(storage_err)?;
-    client
-        .execute(
-            "DELETE FROM backtest_equity_points WHERE export_run_id = $1",
-            &[&export_run_id],
-        )
-        .map_err(storage_err)?;
-
-    let mut trade_rows = 0usize;
-    for trade in &report.trades {
-        insert_backtest_trade_row(&mut client, export_run_id, trade)?;
-        trade_rows += 1;
-    }
-
-    let start_time = report
-        .from
-        .and_hms_opt(0, 0, 0)
-        .ok_or_else(|| StorageError::WriteFailedWithContext {
-            message: format!("invalid backtest start date: {}", report.from),
+        .map(|_| ())
+        .map_err(|error| StorageError::WriteFailedWithContext {
+            message: format!("insert backtest_trades failed: {error:?}"),
         })
-        .map(|value| Utc.from_utc_datetime(&value))?;
-    let mut equity_point_rows = 0usize;
-    insert_backtest_equity_point(
-        &mut client,
-        export_run_id,
-        0,
-        start_time,
-        report.starting_equity,
-        0.0,
-    )?;
-    equity_point_rows += 1;
+}
+
+fn insert_backtest_equity_point(
+    client: &mut impl GenericClient,
+    export_run_id: i64,
+    point: &BacktestEquityPoint,
+) -> Result<(), StorageError> {
+    let event_time_ms = point.event_time_ms as f64;
+    client
+        .execute(
+            "INSERT INTO backtest_equity_points (
+                export_run_id, point_id, event_time, equity, cumulative_net_pnl
+             ) VALUES ($1, $2, to_timestamp($3::double precision / 1000.0), $4, $5)",
+            &[
+                &export_run_id,
+                &point.point_id,
+                &event_time_ms,
+                &point.equity,
+                &point.cumulative_net_pnl,
+            ],
+        )
+        .map(|_| ())
+        .map_err(|error| StorageError::WriteFailedWithContext {
+            message: format!("insert backtest_equity_points failed: {error:?}"),
+        })
+}
+
+fn build_backtest_equity_points(
+    report: &BacktestReport,
+) -> Result<Vec<BacktestEquityPoint>, StorageError> {
+    let start_time =
+        report
+            .from
+            .and_hms_opt(0, 0, 0)
+            .ok_or_else(|| StorageError::WriteFailedWithContext {
+                message: format!("invalid backtest start date: {}", report.from),
+            })?;
+    let mut points = vec![BacktestEquityPoint {
+        point_id: 0,
+        event_time_ms: chrono::DateTime::<Utc>::from_naive_utc_and_offset(start_time, Utc)
+            .timestamp_millis(),
+        equity: report.starting_equity,
+        cumulative_net_pnl: 0.0,
+    }];
 
     let mut realized = report
         .trades
         .iter()
-        .filter_map(|trade| Some((trade.exit_time?, trade.net_pnl?, trade.trade_id as i64)))
+        .filter_map(|trade| Some((trade.exit_time?, trade.net_pnl?)))
         .collect::<Vec<_>>();
-    realized.sort_by(|left, right| left.0.cmp(&right.0).then(left.2.cmp(&right.2)));
+    realized.sort_by_key(|(event_time, _)| *event_time);
 
-    let mut cumulative_net_pnl = 0.0f64;
-    for (index, (exit_time, net_pnl, _)) in realized.into_iter().enumerate() {
+    let mut cumulative_net_pnl = 0.0;
+    let mut point_id = 1i64;
+    for (event_time, net_pnl) in realized {
         cumulative_net_pnl += net_pnl;
-        insert_backtest_equity_point(
-            &mut client,
-            export_run_id,
-            index as i64 + 1,
-            exit_time,
-            report.starting_equity + cumulative_net_pnl,
+        points.push(BacktestEquityPoint {
+            point_id,
+            event_time_ms: event_time.timestamp_millis(),
+            equity: report.starting_equity + cumulative_net_pnl,
             cumulative_net_pnl,
-        )?;
-        equity_point_rows += 1;
+        });
+        point_id += 1;
     }
 
-    Ok(PostgresBacktestExportReport {
-        export_run_id,
-        source_run_id,
-        trade_rows,
-        equity_point_rows,
-    })
+    if points.len() == 1 {
+        let end_time = report.to.and_hms_opt(23, 59, 59).ok_or_else(|| {
+            StorageError::WriteFailedWithContext {
+                message: format!("invalid backtest end date: {}", report.to),
+            }
+        })?;
+        points.push(BacktestEquityPoint {
+            point_id,
+            event_time_ms: chrono::DateTime::<Utc>::from_naive_utc_and_offset(end_time, Utc)
+                .timestamp_millis(),
+            equity: report.ending_equity,
+            cumulative_net_pnl: report.net_pnl,
+        });
+    }
+
+    Ok(points)
+}
+
+fn next_backtest_source_run_id(
+    client: &mut Client,
+    source_db_path: &str,
+) -> Result<i64, StorageError> {
+    client
+        .query_one(
+            "SELECT COALESCE(MAX(source_run_id), 0) + 1
+             FROM backtest_runs
+             WHERE source_db_path = $1",
+            &[&source_db_path],
+        )
+        .map(|row| row.get(0))
+        .map_err(storage_err)
 }
 
 fn existing_schema_version(client: &mut Client) -> Result<Option<String>, StorageError> {
@@ -918,6 +1452,44 @@ fn query_count(client: &mut Client, table: &str) -> Result<u64, StorageError> {
         .map(|row| row.get::<_, i64>(0).max(0) as u64)
 }
 
+fn postgres_count_in_range(
+    client: &mut Client,
+    table: &str,
+    time_column: &str,
+    symbol: &str,
+    from_time_ms: f64,
+    to_time_ms: f64,
+) -> Result<u64, StorageError> {
+    client
+        .query_one(
+            &format!(
+                "SELECT COUNT(*) FROM {table}
+                 WHERE symbol = $1
+                   AND {time_column} >= to_timestamp($2::double precision / 1000.0)
+                   AND {time_column} <= to_timestamp($3::double precision / 1000.0)"
+            ),
+            &[&symbol, &from_time_ms, &to_time_ms],
+        )
+        .map_err(storage_err)
+        .map(|row| row.get::<_, i64>(0).max(0) as u64)
+}
+
+fn raw_kline_interval_rank(interval: &str) -> usize {
+    match interval {
+        "1m" => 0,
+        "3m" => 1,
+        "5m" => 2,
+        "15m" => 3,
+        "30m" => 4,
+        "1h" => 5,
+        "4h" => 6,
+        "1d" => 7,
+        "1w" => 8,
+        "1mo" => 9,
+        _ => usize::MAX,
+    }
+}
+
 fn query_latest_timestamp(
     client: &mut Client,
     table: &str,
@@ -930,6 +1502,48 @@ fn query_latest_timestamp(
         )
         .map_err(storage_err)
         .map(|row| row.get(0))
+}
+
+fn query_latest_timestamp_and_age(
+    client: &mut Client,
+    table: &str,
+    column: &str,
+) -> Result<(Option<String>, Option<i64>), StorageError> {
+    client
+        .query_one(
+            &format!(
+                "SELECT
+                    CAST(MAX({column}) AS TEXT),
+                    CASE
+                        WHEN MAX({column}) IS NULL THEN NULL
+                        ELSE CAST(EXTRACT(EPOCH FROM (NOW() - MAX({column}))) AS BIGINT)
+                    END
+                 FROM {table}"
+            ),
+            &[],
+        )
+        .map_err(storage_err)
+        .map(|row| (row.get(0), row.get(1)))
+}
+
+fn query_latest_kline_timestamp_and_age(
+    client: &mut Client,
+    interval_name: &str,
+) -> Result<(Option<String>, Option<i64>), StorageError> {
+    client
+        .query_one(
+            "SELECT
+                CAST(MAX(close_time) AS TEXT),
+                CASE
+                    WHEN MAX(close_time) IS NULL THEN NULL
+                    ELSE CAST(EXTRACT(EPOCH FROM (NOW() - MAX(close_time))) AS BIGINT)
+                END
+             FROM raw_klines
+             WHERE interval_name = $1",
+            &[&interval_name],
+        )
+        .map_err(storage_err)
+        .map(|row| (row.get(0), row.get(1)))
 }
 
 fn query_top_symbols(client: &mut Client, table: &str) -> Result<Vec<String>, StorageError> {
@@ -948,173 +1562,8 @@ fn query_top_symbols(client: &mut Client, table: &str) -> Result<Vec<String>, St
         })
 }
 
-fn upsert_backtest_run(
-    client: &mut Client,
-    report: &BacktestReport,
-    source_run_id: i64,
-) -> Result<i64, StorageError> {
-    let closed_trades = report
-        .trades
-        .iter()
-        .filter(|trade| trade.net_pnl.is_some())
-        .count() as i64;
-    let mode = report.mode.as_str().to_string();
-    let template = report.template.slug().to_string();
-    let instrument = report.instrument.clone();
-    let source_db_path = report.db_path.display().to_string();
-    client
-        .query_one(
-            "INSERT INTO backtest_runs (
-                source_db_path, source_run_id, mode, template, instrument, from_date, to_date,
-                liquidation_events, book_ticker_events, agg_trade_events, derived_kline_1s_bars,
-                trigger_count, closed_trades, open_trades, wins, losses, skipped_triggers,
-                starting_equity, ending_equity, net_pnl, observed_win_rate, average_net_pnl,
-                configured_expected_value, risk_pct, win_rate_assumption, r_multiple,
-                max_entry_slippage_pct, stop_distance_pct
-             ) VALUES (
-                $1, $2, $3, $4, $5, $6, $7,
-                $8, $9, $10, $11, $12, $13, $14, $15, $16, $17,
-                $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28
-             )
-             ON CONFLICT (source_db_path, source_run_id) DO UPDATE SET
-                exported_at = CURRENT_TIMESTAMP,
-                mode = EXCLUDED.mode,
-                template = EXCLUDED.template,
-                instrument = EXCLUDED.instrument,
-                from_date = EXCLUDED.from_date,
-                to_date = EXCLUDED.to_date,
-                liquidation_events = EXCLUDED.liquidation_events,
-                book_ticker_events = EXCLUDED.book_ticker_events,
-                agg_trade_events = EXCLUDED.agg_trade_events,
-                derived_kline_1s_bars = EXCLUDED.derived_kline_1s_bars,
-                trigger_count = EXCLUDED.trigger_count,
-                closed_trades = EXCLUDED.closed_trades,
-                open_trades = EXCLUDED.open_trades,
-                wins = EXCLUDED.wins,
-                losses = EXCLUDED.losses,
-                skipped_triggers = EXCLUDED.skipped_triggers,
-                starting_equity = EXCLUDED.starting_equity,
-                ending_equity = EXCLUDED.ending_equity,
-                net_pnl = EXCLUDED.net_pnl,
-                observed_win_rate = EXCLUDED.observed_win_rate,
-                average_net_pnl = EXCLUDED.average_net_pnl,
-                configured_expected_value = EXCLUDED.configured_expected_value,
-                risk_pct = EXCLUDED.risk_pct,
-                win_rate_assumption = EXCLUDED.win_rate_assumption,
-                r_multiple = EXCLUDED.r_multiple,
-                max_entry_slippage_pct = EXCLUDED.max_entry_slippage_pct,
-                stop_distance_pct = EXCLUDED.stop_distance_pct
-            RETURNING export_run_id",
-            &[
-                &source_db_path,
-                &source_run_id,
-                &mode,
-                &template,
-                &instrument,
-                &report.from,
-                &report.to,
-                &(report.dataset.liquidation_events as i64),
-                &(report.dataset.book_ticker_events as i64),
-                &(report.dataset.agg_trade_events as i64),
-                &(report.dataset.derived_kline_1s_bars as i64),
-                &(report.trigger_count as i64),
-                &closed_trades,
-                &(report.open_trades as i64),
-                &(report.wins as i64),
-                &(report.losses as i64),
-                &(report.skipped_triggers as i64),
-                &report.starting_equity,
-                &report.ending_equity,
-                &report.net_pnl,
-                &report.observed_win_rate,
-                &report.average_net_pnl,
-                &report.configured_expected_value,
-                &report.config.risk_pct,
-                &report.config.win_rate_assumption,
-                &report.config.r_multiple,
-                &report.config.max_entry_slippage_pct,
-                &report.config.stop_distance_pct,
-            ],
-        )
-        .map_err(|error| StorageError::WriteFailedWithContext {
-            message: format!(
-                "upsert backtest run failed: source_run_id={} instrument={} template={} message={error}",
-                source_run_id,
-                report.instrument,
-                report.template.slug(),
-            ),
-        })
-        .map(|row| row.get(0))
-}
-
-fn insert_backtest_trade_row(
-    client: &mut Client,
-    export_run_id: i64,
-    trade: &BacktestTrade,
-) -> Result<(), StorageError> {
-    client
-        .execute(
-            "INSERT INTO backtest_trades (
-                export_run_id, trade_id, trigger_time, entry_time, entry_price, stop_price,
-                take_profit_price, qty, exit_time, exit_price, exit_reason, gross_pnl, fees, net_pnl
-             ) VALUES (
-                $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14
-             )",
-            &[
-                &export_run_id,
-                &(trade.trade_id as i64),
-                &trade.trigger_time,
-                &trade.entry_time,
-                &trade.entry_price,
-                &trade.stop_price,
-                &trade.take_profit_price,
-                &trade.qty,
-                &trade.exit_time,
-                &trade.exit_price,
-                &trade.exit_reason.as_ref().map(|reason| reason.as_str()),
-                &trade.gross_pnl,
-                &trade.fees,
-                &trade.net_pnl,
-            ],
-        )
-        .map(|_| ())
-        .map_err(|error| StorageError::WriteFailedWithContext {
-            message: format!(
-                "insert backtest trade failed: trade_id={} message={error}",
-                trade.trade_id
-            ),
-        })
-}
-
-fn insert_backtest_equity_point(
-    client: &mut Client,
-    export_run_id: i64,
-    point_id: i64,
-    event_time: chrono::DateTime<Utc>,
-    equity: f64,
-    cumulative_net_pnl: f64,
-) -> Result<(), StorageError> {
-    client
-        .execute(
-            "INSERT INTO backtest_equity_points (
-                export_run_id, point_id, event_time, equity, cumulative_net_pnl
-             ) VALUES (
-                $1, $2, $3, $4, $5
-             )",
-            &[&export_run_id, &point_id, &event_time, &equity, &cumulative_net_pnl],
-        )
-        .map(|_| ())
-        .map_err(|error| StorageError::WriteFailedWithContext {
-            message: format!(
-                "insert backtest equity point failed: point_id={} message={error}",
-                point_id
-            ),
-        })
-}
-
 fn clear_duckdb_klines(
     duck: &DuckConnection,
-    mode: BinanceMode,
     symbol: &str,
     product: Option<&str>,
     interval_name: Option<&str>,
@@ -1123,14 +1572,12 @@ fn clear_duckdb_klines(
 ) -> Result<(), StorageError> {
     duck.execute(
         "DELETE FROM raw_klines
-         WHERE mode = ?
-           AND symbol = ?
+         WHERE symbol = ?
            AND open_time >= CAST(? AS TIMESTAMP)
            AND open_time <= CAST(? AS TIMESTAMP)
            AND (? IS NULL OR product = ?)
            AND (? IS NULL OR interval = ?)",
         params![
-            mode.as_str(),
             symbol,
             from_ts,
             to_ts,
@@ -1146,18 +1593,16 @@ fn clear_duckdb_klines(
 
 fn clear_duckdb_liquidations(
     duck: &DuckConnection,
-    mode: BinanceMode,
     symbol: &str,
     from_ts: &str,
     to_ts: &str,
 ) -> Result<(), StorageError> {
     duck.execute(
         "DELETE FROM raw_liquidation_events
-         WHERE mode = ?
-           AND symbol = ?
+         WHERE symbol = ?
            AND event_time >= CAST(? AS TIMESTAMP)
            AND event_time <= CAST(? AS TIMESTAMP)",
-        params![mode.as_str(), symbol, from_ts, to_ts],
+        params![symbol, from_ts, to_ts],
     )
     .map(|_| ())
     .map_err(storage_err)
@@ -1165,18 +1610,16 @@ fn clear_duckdb_liquidations(
 
 fn clear_duckdb_book_tickers(
     duck: &DuckConnection,
-    mode: BinanceMode,
     symbol: &str,
     from_ts: &str,
     to_ts: &str,
 ) -> Result<(), StorageError> {
     duck.execute(
         "DELETE FROM raw_book_ticker
-         WHERE mode = ?
-           AND symbol = ?
+         WHERE symbol = ?
            AND event_time >= CAST(? AS TIMESTAMP)
            AND event_time <= CAST(? AS TIMESTAMP)",
-        params![mode.as_str(), symbol, from_ts, to_ts],
+        params![symbol, from_ts, to_ts],
     )
     .map(|_| ())
     .map_err(storage_err)
@@ -1184,18 +1627,16 @@ fn clear_duckdb_book_tickers(
 
 fn clear_duckdb_agg_trades(
     duck: &DuckConnection,
-    mode: BinanceMode,
     symbol: &str,
     from_ts: &str,
     to_ts: &str,
 ) -> Result<(), StorageError> {
     duck.execute(
         "DELETE FROM raw_agg_trades
-         WHERE mode = ?
-           AND symbol = ?
+         WHERE symbol = ?
            AND event_time >= CAST(? AS TIMESTAMP)
            AND event_time <= CAST(? AS TIMESTAMP)",
-        params![mode.as_str(), symbol, from_ts, to_ts],
+        params![symbol, from_ts, to_ts],
     )
     .map(|_| ())
     .map_err(storage_err)
@@ -1249,4 +1690,12 @@ fn storage_err(error: impl std::fmt::Display) -> StorageError {
     StorageError::WriteFailedWithContext {
         message: error.to_string(),
     }
+}
+
+fn timestamp_from_millis(value: i64) -> Result<chrono::DateTime<Utc>, StorageError> {
+    Utc.timestamp_millis_opt(value)
+        .single()
+        .ok_or_else(|| StorageError::WriteFailedWithContext {
+            message: format!("invalid timestamp millis: {value}"),
+        })
 }

--- a/src/strategy/model.rs
+++ b/src/strategy/model.rs
@@ -8,6 +8,9 @@ use crate::strategy::command::StrategyStartConfig;
 pub enum StrategyTemplate {
     LiquidationBreakdownShort,
     PriceSmaCrossLong,
+    PriceSmaCrossShort,
+    PriceSmaCrossLongFast,
+    PriceSmaCrossShortFast,
 }
 
 impl StrategyTemplate {
@@ -15,10 +18,13 @@ impl StrategyTemplate {
         match self {
             Self::LiquidationBreakdownShort => "liquidation-breakdown-short",
             Self::PriceSmaCrossLong => "price-sma-cross-long",
+            Self::PriceSmaCrossShort => "price-sma-cross-short",
+            Self::PriceSmaCrossLongFast => "price-sma-cross-long-fast",
+            Self::PriceSmaCrossShortFast => "price-sma-cross-short-fast",
         }
     }
 
-    pub fn steps(self) -> &'static [&'static str; 7] {
+    pub fn steps(self) -> &'static [&'static str] {
         match self {
             Self::LiquidationBreakdownShort => &[
                 "Find a liquidation cluster above current price",
@@ -30,19 +36,44 @@ impl StrategyTemplate {
                 "End the strategy after exchange protection is live",
             ],
             Self::PriceSmaCrossLong => &[
-                "Read historical trend state from price bars",
-                "Track moving-average cross signals",
-                "Enter long after confirmed bullish cross",
-                "Apply configured stop and take-profit bounds",
-                "Manage the position until exit",
-                "Record realized PnL for the completed trade",
-                "Close any remaining position at the end of the window",
+                "Read raw futures kline closes from the selected interval",
+                "Compute fast and slow simple moving averages on price",
+                "Enter long when the fast average crosses above the slow average",
+                "Manage the position with stop loss, take profit, or bearish cross exit",
+                "Close any remaining position at the end of the backtest window",
+            ],
+            Self::PriceSmaCrossShort => &[
+                "Read raw futures kline closes from the selected interval",
+                "Compute fast and slow simple moving averages on price",
+                "Enter short when the fast average crosses below the slow average",
+                "Manage the position with stop loss, take profit, or bullish cross exit",
+                "Close any remaining position at the end of the backtest window",
+            ],
+            Self::PriceSmaCrossLongFast => &[
+                "Read raw futures kline closes from the selected interval",
+                "Compute faster 9/21 simple moving averages on price",
+                "Enter long when the fast average crosses above the slow average",
+                "Manage the position with stop loss, take profit, or bearish cross exit",
+                "Close any remaining position at the end of the backtest window",
+            ],
+            Self::PriceSmaCrossShortFast => &[
+                "Read raw futures kline closes from the selected interval",
+                "Compute faster 9/21 simple moving averages on price",
+                "Enter short when the fast average crosses below the slow average",
+                "Manage the position with stop loss, take profit, or bullish cross exit",
+                "Close any remaining position at the end of the backtest window",
             ],
         }
     }
 
-    pub fn all() -> [Self; 1] {
-        [Self::LiquidationBreakdownShort]
+    pub fn all() -> [Self; 5] {
+        [
+            Self::LiquidationBreakdownShort,
+            Self::PriceSmaCrossLong,
+            Self::PriceSmaCrossShort,
+            Self::PriceSmaCrossLongFast,
+            Self::PriceSmaCrossShortFast,
+        ]
     }
 }
 

--- a/src/ui/backtest_output.rs
+++ b/src/ui/backtest_output.rs
@@ -1,5 +1,6 @@
 use crate::backtest_app::runner::BacktestReport;
 use crate::dataset::types::BacktestRunSummaryRow;
+use crate::strategy::model::StrategyTemplate;
 
 pub fn render_backtest_run(report: &BacktestReport) -> String {
     let realized_trade_count = report
@@ -35,18 +36,7 @@ pub fn render_backtest_run(report: &BacktestReport) -> String {
             "derived_kline_1s_bars={}",
             report.dataset.derived_kline_1s_bars
         ),
-        format!(
-            "state={}",
-            if !report.dataset.symbol_found {
-                "symbol_not_found"
-            } else if !has_dataset_rows {
-                "empty_dataset"
-            } else if report.trades.is_empty() {
-                "no_trades"
-            } else {
-                "ok"
-            }
-        ),
+        format!("state={}", report_state(report, has_dataset_rows)),
         "[results]".to_string(),
         format!("trigger_count={}", report.trigger_count),
         format!("closed_trades={}", realized_trade_count),
@@ -61,15 +51,7 @@ pub fn render_backtest_run(report: &BacktestReport) -> String {
         format!("average_net_pnl={:.2}", report.average_net_pnl),
         format!(
             "summary=state:{} trades:{}/{} pnl:{:.2} equity:{:.2}->{:.2}",
-            if !report.dataset.symbol_found {
-                "symbol_not_found"
-            } else if !has_dataset_rows {
-                "empty_dataset"
-            } else if report.trades.is_empty() {
-                "no_trades"
-            } else {
-                "ok"
-            },
+            report_state(report, has_dataset_rows),
             realized_trade_count,
             report.trigger_count,
             report.net_pnl,
@@ -118,6 +100,51 @@ pub fn render_backtest_run(report: &BacktestReport) -> String {
     }
 
     lines.join("\n")
+}
+
+fn report_state(report: &BacktestReport, has_dataset_rows: bool) -> &'static str {
+    if !report.dataset.symbol_found {
+        return "symbol_not_found";
+    }
+    match report.template {
+        StrategyTemplate::LiquidationBreakdownShort => {
+            if !has_dataset_rows {
+                "empty_dataset"
+            } else if report.trades.is_empty() {
+                "no_trades"
+            } else {
+                "ok"
+            }
+        }
+        StrategyTemplate::PriceSmaCrossLong => {
+            if report.trades.is_empty() {
+                "no_trades"
+            } else {
+                "ok"
+            }
+        }
+        StrategyTemplate::PriceSmaCrossShort => {
+            if report.trades.is_empty() {
+                "no_trades"
+            } else {
+                "ok"
+            }
+        }
+        StrategyTemplate::PriceSmaCrossLongFast => {
+            if report.trades.is_empty() {
+                "no_trades"
+            } else {
+                "ok"
+            }
+        }
+        StrategyTemplate::PriceSmaCrossShortFast => {
+            if report.trades.is_empty() {
+                "no_trades"
+            } else {
+                "ok"
+            }
+        }
+    }
 }
 
 pub fn render_backtest_run_list(runs: &[BacktestRunSummaryRow]) -> String {

--- a/src/ui/operator_output.rs
+++ b/src/ui/operator_output.rs
@@ -34,18 +34,17 @@ fn render_strategy_output(
 ) -> String {
     match command {
         StrategyCommand::Templates => {
+            let templates = crate::strategy::model::StrategyTemplate::all();
             let mut lines = vec![
                 "strategy templates".to_string(),
                 format!("mode={}", mode.as_str()),
-                "templates=1".to_string(),
-                "template=liquidation-breakdown-short".to_string(),
+                format!("templates={}", templates.len()),
             ];
-            for (index, step) in crate::strategy::model::StrategyTemplate::LiquidationBreakdownShort
-                .steps()
-                .iter()
-                .enumerate()
-            {
-                lines.push(format!("{}. {}", index + 1, step));
+            for template in templates {
+                lines.push(format!("template={}", template.slug()));
+                for (index, step) in template.steps().iter().enumerate() {
+                    lines.push(format!("{}. {}", index + 1, step));
+                }
             }
             lines.join("\n")
         }
@@ -61,12 +60,13 @@ fn render_strategy_output(
             } else {
                 lines.extend(watches.into_iter().map(|watch| {
                     format!(
-                        "- id={} template={} instrument={} state={} step={}/7",
+                        "- id={} template={} instrument={} state={} step={}/{}",
                         watch.id,
                         watch.template.slug(),
                         watch.instrument.0,
                         watch.state.as_str(),
-                        watch.current_step
+                        watch.current_step,
+                        watch.template.steps().len()
                     )
                 }));
             }
@@ -109,7 +109,11 @@ fn render_strategy_output(
                 format!("template={}", watch.template.slug()),
                 format!("instrument={}", watch.instrument.0),
                 format!("state={}", watch.state.as_str()),
-                format!("current_step={}/7", watch.current_step),
+                format!(
+                    "current_step={}/{}",
+                    watch.current_step,
+                    watch.template.steps().len()
+                ),
                 format!("risk_pct={}", watch.config.risk_pct),
                 format!("win_rate={}", watch.config.win_rate),
                 format!("r_multiple={}", watch.config.r_multiple),
@@ -128,12 +132,12 @@ fn render_strategy_output(
             }
             lines.join("\n")
         }
-        StrategyCommand::Start { .. } => {
+        StrategyCommand::Start { template, .. } => {
             let Some(last_event) = event_log.records.last() else {
                 return "strategy started\nlast_event=none".to_string();
             };
             format!(
-                "strategy started\nmode={}\nwatch_id={}\ntemplate={}\ninstrument={}\nstate={}\nrisk_pct={}\nwin_rate={}\nr_multiple={}\nmax_entry_slippage_pct={}\ncurrent_step={}/7",
+                "strategy started\nmode={}\nwatch_id={}\ntemplate={}\ninstrument={}\nstate={}\nrisk_pct={}\nwin_rate={}\nr_multiple={}\nmax_entry_slippage_pct={}\ncurrent_step={}/{}",
                 last_event.payload["mode"].as_str().unwrap_or("unknown"),
                 last_event.payload["watch_id"].as_u64().unwrap_or_default(),
                 last_event.payload["template"].as_str().unwrap_or("unknown"),
@@ -144,6 +148,7 @@ fn render_strategy_output(
                 last_event.payload["r_multiple"].as_f64().unwrap_or_default(),
                 last_event.payload["max_entry_slippage_pct"].as_f64().unwrap_or_default(),
                 last_event.payload["current_step"].as_u64().unwrap_or_default(),
+                template.steps().len(),
             )
         }
         StrategyCommand::Stop { .. } => {

--- a/src/ui/recorder_output.rs
+++ b/src/ui/recorder_output.rs
@@ -3,18 +3,21 @@ use crate::recorder_app::runtime::RecorderStatus;
 pub fn render_live_recorder_status(header: &str, status: &RecorderStatus) -> String {
     let mut lines = vec![
         header.to_string(),
-        format!("mode={}", status.mode.as_str()),
         format!("state={}", status.state.as_str()),
         format!("desired_running={}", status.state.is_running()),
         format!("process_alive={}", status.worker_alive),
+        format!("reader_alive={}", status.reader_alive),
+        format!("writer_alive={}", status.writer_alive),
         format!("worker_alive={}", status.worker_alive),
-        format!("status_stale={}", status.heartbeat_age_sec > 5),
+        format!(
+            "status_stale={}",
+            status.heartbeat_age_sec > 5 || !status.worker_alive
+        ),
         format!("heartbeat_age_sec={}", status.heartbeat_age_sec),
         "pid=in-process".to_string(),
         format!("binary_version={}", env!("CARGO_PKG_VERSION")),
         format!("storage_backend={}", status.storage_backend),
         format!("storage_target={}", status.storage_target),
-        format!("db_path={}", status.db_path.display()),
         format!(
             "schema_version={}",
             status
@@ -78,6 +81,9 @@ pub fn render_live_recorder_status(header: &str, status: &RecorderStatus) -> Str
             join_symbols(&status.metrics.top_agg_trade_symbols)
         ),
     ];
+    if status.storage_backend == "duckdb" {
+        lines.push(format!("db_path={}", status.db_path.display()));
+    }
     if let Some(error) = &status.last_error {
         lines.push(format!("last_error={error}"));
     }
@@ -113,6 +119,8 @@ mod tests {
             manual_symbols: Vec::new(),
             strategy_symbols: Vec::new(),
             watched_symbols: Vec::new(),
+            reader_alive: false,
+            writer_alive: false,
             worker_alive: false,
             heartbeat_age_sec: 0,
             last_error: None,

--- a/tests/app_runtime_tests.rs
+++ b/tests/app_runtime_tests.rs
@@ -91,14 +91,15 @@ fn app_runtime_executes_command_and_logs_event() {
         )
         .expect("execution command should succeed");
 
-    assert_eq!(app.event_log.records.len(), 4);
+    assert_eq!(app.event_log.records.len(), 5);
     assert_eq!(app.event_log.records[0].kind, "app.portfolio.refreshed");
     assert_eq!(
         app.event_log.records[1].kind,
         "app.market_data.price_refreshed"
     );
-    assert_eq!(app.event_log.records[2].kind, "app.portfolio.refreshed");
-    assert_eq!(app.event_log.records[3].kind, "app.execution.completed");
+    assert_eq!(app.event_log.records[2].kind, "app.execution.started");
+    assert_eq!(app.event_log.records[3].kind, "app.portfolio.refreshed");
+    assert_eq!(app.event_log.records[4].kind, "app.execution.completed");
     assert_eq!(app.event_log.records[1].payload["price"], 50000.0);
 }
 
@@ -160,14 +161,15 @@ fn app_runtime_executes_target_exposure_from_flat_position() {
         )
         .expect("flat target exposure should succeed");
 
-    assert_eq!(app.event_log.records.len(), 4);
+    assert_eq!(app.event_log.records.len(), 5);
     assert_eq!(app.event_log.records[0].kind, "app.portfolio.refreshed");
     assert_eq!(
         app.event_log.records[1].kind,
         "app.market_data.price_refreshed"
     );
-    assert_eq!(app.event_log.records[2].kind, "app.portfolio.refreshed");
-    assert_eq!(app.event_log.records[3].kind, "app.execution.completed");
+    assert_eq!(app.event_log.records[2].kind, "app.execution.started");
+    assert_eq!(app.event_log.records[3].kind, "app.portfolio.refreshed");
+    assert_eq!(app.event_log.records[4].kind, "app.execution.completed");
 }
 
 #[test]
@@ -263,10 +265,11 @@ fn app_runtime_executes_option_order_and_logs_event() {
         .expect("option order should succeed");
 
     assert_eq!(app.event_log.records[0].kind, "app.portfolio.refreshed");
-    assert_eq!(app.event_log.records[1].kind, "app.portfolio.refreshed");
-    assert_eq!(app.event_log.records[2].kind, "app.execution.completed");
+    assert_eq!(app.event_log.records[1].kind, "app.execution.started");
+    assert_eq!(app.event_log.records[2].kind, "app.portfolio.refreshed");
+    assert_eq!(app.event_log.records[3].kind, "app.execution.completed");
     assert_eq!(
-        app.event_log.records[2].payload["command_kind"],
+        app.event_log.records[3].payload["command_kind"],
         "submit_option_order"
     );
 }
@@ -483,7 +486,8 @@ fn app_runtime_refreshes_after_close_all_and_reports_remaining_positions() {
         )
         .expect("close-all should succeed");
 
-    assert_eq!(app.event_log.records[1].kind, "app.portfolio.refreshed");
-    assert_eq!(app.event_log.records[2].kind, "app.execution.completed");
-    assert_eq!(app.event_log.records[2].payload["remaining_positions"], 0);
+    assert_eq!(app.event_log.records[1].kind, "app.execution.started");
+    assert_eq!(app.event_log.records[2].kind, "app.portfolio.refreshed");
+    assert_eq!(app.event_log.records[3].kind, "app.execution.completed");
+    assert_eq!(app.event_log.records[3].payload["remaining_positions"], 0);
 }

--- a/tests/gui_charting_tests.rs
+++ b/tests/gui_charting_tests.rs
@@ -8,8 +8,8 @@ use sandbox_quant::backtest_app::runner::{
     BacktestConfig, BacktestExitReason, BacktestReport, BacktestTrade,
 };
 use sandbox_quant::charting::adapters::sandbox::{
-    equity_scene_from_report, market_scene_from_snapshot,
-    market_scene_from_snapshot_with_timeframe, MarketTimeframe,
+    equity_scene_from_report, market_scene_from_snapshot, market_scene_from_snapshot_with_overlay,
+    market_scene_from_snapshot_with_timeframe, MarketSeriesKind, MarketTimeframe,
 };
 use sandbox_quant::charting::scene::Series;
 use sandbox_quant::dataset::types::{
@@ -216,6 +216,118 @@ fn market_scene_uses_candles_and_volume_when_klines_exist() {
         .series
         .iter()
         .any(|series| matches!(series, Series::Bars(_))));
+}
+
+#[test]
+fn market_scene_overlay_can_include_two_series_in_one_pane() {
+    let snapshot = sample_snapshot(
+        "BTCUSDT",
+        vec![
+            BookTickerRow {
+                event_time_ms: 1_000,
+                bid: 99.0,
+                ask: 101.0,
+            },
+            BookTickerRow {
+                event_time_ms: 2_000,
+                bid: 100.0,
+                ask: 102.0,
+            },
+        ],
+        vec![
+            DerivedKlineRow {
+                open_time_ms: 1_000,
+                close_time_ms: 1_999,
+                open: 100.0,
+                high: 103.0,
+                low: 99.0,
+                close: 102.0,
+                volume: 25.0,
+                quote_volume: 2_550.0,
+                trade_count: 10,
+            },
+            DerivedKlineRow {
+                open_time_ms: 2_000,
+                close_time_ms: 2_999,
+                open: 102.0,
+                high: 104.0,
+                low: 101.0,
+                close: 101.5,
+                volume: 20.0,
+                quote_volume: 2_035.0,
+                trade_count: 8,
+            },
+        ],
+        None,
+    );
+
+    let scene = market_scene_from_snapshot_with_overlay(
+        &snapshot,
+        MarketTimeframe::Tick1s,
+        MarketSeriesKind::Candles,
+        Some(MarketSeriesKind::CloseLine),
+    );
+
+    let has_candles = scene.panes[0]
+        .series
+        .iter()
+        .any(|series| matches!(series, Series::Candles(_)));
+    let line_count = scene.panes[0]
+        .series
+        .iter()
+        .filter(|series| matches!(series, Series::Line(_)))
+        .count();
+
+    assert!(has_candles);
+    assert!(line_count >= 1);
+}
+
+#[test]
+fn market_scene_overlay_supports_ema_and_vwap_lines() {
+    let snapshot = sample_snapshot(
+        "BTCUSDT",
+        Vec::new(),
+        vec![
+            DerivedKlineRow {
+                open_time_ms: 1_000,
+                close_time_ms: 1_999,
+                open: 100.0,
+                high: 103.0,
+                low: 99.0,
+                close: 102.0,
+                volume: 25.0,
+                quote_volume: 2_550.0,
+                trade_count: 10,
+            },
+            DerivedKlineRow {
+                open_time_ms: 2_000,
+                close_time_ms: 2_999,
+                open: 102.0,
+                high: 104.0,
+                low: 101.0,
+                close: 101.5,
+                volume: 20.0,
+                quote_volume: 2_035.0,
+                trade_count: 8,
+            },
+        ],
+        None,
+    );
+
+    let scene = market_scene_from_snapshot_with_overlay(
+        &snapshot,
+        MarketTimeframe::Tick1s,
+        MarketSeriesKind::Ema20,
+        Some(MarketSeriesKind::Vwap),
+    );
+
+    let line_count = scene.panes[0]
+        .series
+        .iter()
+        .filter(|series| matches!(series, Series::Line(_)))
+        .count();
+
+    assert!(line_count >= 2);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- refactor recorder into a managed daemon with in-process Binance kline backfill and freshness APIs
- add trading-engine serve/status/health/stop control plane plus remote execution endpoints
- align PostgreSQL-backed observability, Grafana docs, and runtime launch flows

## Verification
- cargo check --bin sandbox-quant-recorder --bin sandbox-quant
- cargo test --lib --tests
- verified recorder /health and /freshness plus trading-engine /health and command endpoints locally
